### PR TITLE
Version Control: update the axcpu rev hash in Cargo.toml after axcpu submodule updated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,7 +230,7 @@ dependencies = [
 [[package]]
 name = "axcpu"
 version = "0.2.2"
-source = "git+https://github.com/Starry-OS/axcpu.git?rev=3349bfd#3349bfde4eee627777634431511e5e67076f1db9"
+source = "git+https://github.com/Starry-OS/axcpu.git?rev=a26f7c9#a26f7c9a3d6462d5c88c0ab7426387482af0a077"
 dependencies = [
  "aarch64-cpu",
  "axbacktrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ optional = true
 
 [patch.crates-io]
 axbacktrace = { git = "https://github.com/Starry-OS/axbacktrace.git", rev = "09c22b6" }
-axcpu = { git = "https://github.com/Starry-OS/axcpu.git", rev = "3349bfd" }
+axcpu = { git = "https://github.com/Starry-OS/axcpu.git", rev = "a26f7c9" }
 axerrno = { git = "https://github.com/Starry-OS/axerrno.git", rev = "58be232" }
 axfs-ng-vfs = { git = "https://github.com/Starry-OS/axfs-ng-vfs.git", rev = "3926fb4" }
 axio = { git = "https://github.com/Starry-OS/axio.git", rev = "ebb0c6b" }


### PR DESCRIPTION
Changes:
- Update the axcpu rev hash to the latest one in Cargo.toml after axcpu submodule updated