### PR TITLE
fix: update CI workflow to use harness for aarch64 testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,96 +16,76 @@ jobs:
     with:
       arch: ${{ matrix.arch }}
     secrets: inherit
-  harness:
-    name: Harness CI (aarch64)
-    runs-on: ubuntu-latest
 
+  harness:
+    name: Harness CI Tests
+    runs-on: ubuntu-latest
+    needs: test
     env:
       ARCH: aarch64
-      # StarryOS 的路径由 CI 直接 checkout 到 StarryOS/
-      STARRYOS_ROOT: ${{ github.workspace }}/StarryOS
-
-      # PR 使用 PR head，普通 push 使用 sha
-      STARRYOS_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      RUSTUP_TOOLCHAIN: nightly-2025-05-20
-      SKIP_STARRY_BUILD: 1   # 放在 env 顶层，避免重复设置
-
+      STARRYOS_ROOT: ${{ format('{0}/starry-src', github.workspace) }}
+      STARRYOS_REF: ${{ github.sha }}
+      STARRYOS_REMOTE: ${{ format('https://github.com/{0}.git', github.repository) }}
     steps:
-      # -----------------------------
-      # ① Checkout StarryOS（PR版本）
-      # -----------------------------
-      - name: Checkout StarryOS (current PR)
+      - name: Checkout StarryOS
         uses: actions/checkout@v4
         with:
-          path: StarryOS
-          submodules: recursive
+          path: starry-src
+          submodules: "recursive"
 
-      # -----------------------------
-      # ② Checkout test harness
-      # -----------------------------
-      - name: Checkout Test Harness
+      - name: Checkout test harness
         uses: actions/checkout@v4
         with:
           repository: kylin-x-kernel/starry-test-harness
+          ref: master
           path: starry-test-harness
 
-      # -----------------------------
-      # ③ Install Rust nightly
-      # -----------------------------
-      - name: Install Rust nightly
+       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly-2025-05-20
           components: rustfmt, clippy, llvm-tools-preview, rust-src
           targets: aarch64-unknown-none-softfloat
 
-      # -----------------------------
-      # ④ Cache rootfs
-      # -----------------------------
-      - name: Cache rootfs template
-        uses: actions/cache@v3
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: starry-test-harness/.cache/rootfs
-          key: rootfs-${{ env.ARCH }}-20250917
+          shared-key: starry-ci-harness
+          workspaces: |
+            starry-test-harness
 
-      # -----------------------------
-      # ⑤ Install QEMU & MUSL
-      # -----------------------------
-      - name: Setup QEMU
+      - name: Install musl toolchain
+        uses: arceos-org/setup-musl@v1
+        with:
+          arch: ${{ env.ARCH }}
+
+      - name: Install QEMU
         uses: arceos-org/setup-qemu@v1
         with:
           version: 10.1.0
           arch_list: ${{ env.ARCH }}
 
-      - uses: arceos-org/setup-musl@v1
-        with:
-          arch: ${{ env.ARCH }}
+      - name: Install filesystem tools
+        run: sudo apt-get update && sudo apt-get install -y e2fsprogs
 
-      - run: sudo apt-get update && sudo apt-get install -y e2fsprogs
-
-      # -----------------------------
-      # ⑥ Run test harness
-      # -----------------------------
-      - name: Run test harness ci-test
+      - name: Run harness suite
         working-directory: starry-test-harness
-        env:
-          ARCH: ${{ env.ARCH }}
-          STARRYOS_ROOT: ${{ env.STARRYOS_ROOT }}
-          STARRYOS_COMMIT: ${{ env.STARRYOS_COMMIT }}
-          SKIP_STARRY_BUILD: 1
-          ROOTFS_CACHE_DIR: ${{ github.workspace }}/starry-test-harness/.cache/rootfs
-          CC_aarch64_unknown_linux_musl: aarch64-linux-musl-gcc
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-musl-gcc
         run: make ci-test run
 
-      # -----------------------------
-      # ⑦ Upload logs
-      # -----------------------------
-      - name: Upload harness logs
+      - name: Dump harness logs
+        if: always()
+        working-directory: starry-test-harness
+        run: |
+          if [ -d logs/ci ]; then
+            find logs/ci -name 'suite.log' -print -exec sh -c 'echo "::group::{}"; cat "$1"; echo "::endgroup::"' _ {} \;
+          else
+            echo "logs/ci not found"
+          fi
+
+      - name: Upload harness artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: harness-logs-${{ github.run_id }}
-          path: starry-test-harness/logs/**
+          path: starry-test-harness/logs/ci
           if-no-files-found: warn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,3 +77,4 @@ jobs:
           name: harness-logs-${{ github.run_id }}
           path: starry-test-harness/logs/**
           if-no-files-found: warn
+//test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,69 +7,101 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [riscv64, loongarch64, aarch64, x86_64]
+    uses: ./.github/workflows/test-template.yml
+    with:
+      arch: ${{ matrix.arch }}
+    secrets: inherit
   harness:
     name: Harness CI (aarch64)
     runs-on: ubuntu-latest
 
     env:
       ARCH: aarch64
-      STARRYOS_REMOTE: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git
+      # StarryOS 的路径由 CI 直接 checkout 到 StarryOS/
+      STARRYOS_ROOT: ${{ github.workspace }}/StarryOS
+
+      # PR 使用 PR head，普通 push 使用 sha
       STARRYOS_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+
       RUSTUP_TOOLCHAIN: nightly-2025-05-20
+      SKIP_STARRY_BUILD: 1   # 放在 env 顶层，避免重复设置
 
     steps:
+      # -----------------------------
+      # ① Checkout StarryOS（PR版本）
+      # -----------------------------
       - name: Checkout StarryOS (current PR)
         uses: actions/checkout@v4
         with:
           path: StarryOS
           submodules: recursive
 
+      # -----------------------------
+      # ② Checkout test harness
+      # -----------------------------
       - name: Checkout Test Harness
         uses: actions/checkout@v4
         with:
           repository: kylin-x-kernel/starry-test-harness
           path: starry-test-harness
 
+      # -----------------------------
+      # ③ Install Rust nightly
+      # -----------------------------
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly-2025-05-20
-          components: rustfmt,clippy,llvm-tools-preview,rust-src
+          components: rustfmt, clippy, llvm-tools-preview, rust-src
           targets: aarch64-unknown-none-softfloat
 
+      # -----------------------------
+      # ④ Cache rootfs
+      # -----------------------------
       - name: Cache rootfs template
         uses: actions/cache@v3
         with:
           path: starry-test-harness/.cache/rootfs
           key: rootfs-${{ env.ARCH }}-20250917
 
-
+      # -----------------------------
+      # ⑤ Install QEMU & MUSL
+      # -----------------------------
       - name: Setup QEMU
         uses: arceos-org/setup-qemu@v1
         with:
           version: 10.1.0
           arch_list: ${{ env.ARCH }}
 
-      
       - uses: arceos-org/setup-musl@v1
         with:
           arch: ${{ env.ARCH }}
 
       - run: sudo apt-get update && sudo apt-get install -y e2fsprogs
 
+      # -----------------------------
+      # ⑥ Run test harness
+      # -----------------------------
       - name: Run test harness ci-test
         working-directory: starry-test-harness
         env:
           ARCH: ${{ env.ARCH }}
-          STARRYOS_REMOTE: ${{ env.STARRYOS_REMOTE }}
+          STARRYOS_ROOT: ${{ env.STARRYOS_ROOT }}
           STARRYOS_COMMIT: ${{ env.STARRYOS_COMMIT }}
-          STARRYOS_ROOT: ${{ github.workspace }}/starry-test-harness/.cache/StarryOS
+          SKIP_STARRY_BUILD: 1
           ROOTFS_CACHE_DIR: ${{ github.workspace }}/starry-test-harness/.cache/rootfs
-          SKIP_STARRY_BUILD: ${{ env.SKIP_STARRY_BUILD }}
           CC_aarch64_unknown_linux_musl: aarch64-linux-musl-gcc
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-musl-gcc
         run: make ci-test run
 
+      # -----------------------------
+      # ⑦ Upload logs
+      # -----------------------------
       - name: Upload harness logs
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,73 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [riscv64, loongarch64, aarch64, x86_64]
-    uses: ./.github/workflows/test-template.yml
-    with:
-      arch: ${{ matrix.arch }}
-    secrets: inherit
+  harness:
+    name: Harness CI (aarch64)
+    runs-on: ubuntu-latest
+
+    env:
+      ARCH: aarch64
+      STARRYOS_REMOTE: https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git
+      STARRYOS_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+      RUSTUP_TOOLCHAIN: nightly-2025-05-20
+
+    steps:
+      - name: Checkout StarryOS (current PR)
+        uses: actions/checkout@v4
+        with:
+          path: StarryOS
+          submodules: recursive
+
+      - name: Checkout Test Harness
+        uses: actions/checkout@v4
+        with:
+          repository: kylin-x-kernel/starry-test-harness
+          path: starry-test-harness
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2025-05-20
+          components: rustfmt,clippy,llvm-tools-preview,rust-src
+          targets: aarch64-unknown-none-softfloat
+
+      - name: Cache rootfs template
+        uses: actions/cache@v3
+        with:
+          path: starry-test-harness/.cache/rootfs
+          key: rootfs-${{ env.ARCH }}-20250917
+
+
+      - name: Setup QEMU
+        uses: arceos-org/setup-qemu@v1
+        with:
+          version: 10.1.0
+          arch_list: ${{ env.ARCH }}
+
+      
+      - uses: arceos-org/setup-musl@v1
+        with:
+          arch: ${{ env.ARCH }}
+
+      - run: sudo apt-get update && sudo apt-get install -y e2fsprogs
+
+      - name: Run test harness ci-test
+        working-directory: starry-test-harness
+        env:
+          ARCH: ${{ env.ARCH }}
+          STARRYOS_REMOTE: ${{ env.STARRYOS_REMOTE }}
+          STARRYOS_COMMIT: ${{ env.STARRYOS_COMMIT }}
+          STARRYOS_ROOT: ${{ github.workspace }}/starry-test-harness/.cache/StarryOS
+          ROOTFS_CACHE_DIR: ${{ github.workspace }}/starry-test-harness/.cache/rootfs
+          SKIP_STARRY_BUILD: ${{ env.SKIP_STARRY_BUILD }}
+          CC_aarch64_unknown_linux_musl: aarch64-linux-musl-gcc
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-musl-gcc
+        run: make ci-test run
+
+      - name: Upload harness logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: harness-logs-${{ github.run_id }}
+          path: starry-test-harness/logs/**
+          if-no-files-found: warn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,9 +23,9 @@ jobs:
     needs: test
     env:
       ARCH: aarch64
-      STARRYOS_ROOT: ${{ format('{0}/starry-src', github.workspace) }}
+      STARRYOS_ROOT: ${{ github.workspace }}/starry-src
       STARRYOS_REF: ${{ github.sha }}
-      STARRYOS_REMOTE: ${{ format('https://github.com/{0}.git', github.repository) }}
+      STARRYOS_REMOTE: https://github.com/${{ github.repository }}.git
     steps:
       - name: Checkout StarryOS
         uses: actions/checkout@v4
@@ -40,7 +40,7 @@ jobs:
           ref: master
           path: starry-test-harness
 
-       - name: Install Rust nightly
+      - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly-2025-05-20

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,4 +77,3 @@ jobs:
           name: harness-logs-${{ github.run_id }}
           path: starry-test-harness/logs/**
           if-no-files-found: warn
-//test


### PR DESCRIPTION
### Summary
This PR updates the CI workflow to use the new starry-test-harness for aarch64 testing.

### What’s changed
- Integrate `starry-test-harness` to automatically clone, build and test StarryOS.
- Add QEMU 10.1.0 setup for aarch64 testing.
- Add musl toolchain setup for building aarch64-unknown-none-softfloat targets.
- Add automatic rootfs caching to improve CI speed.
- Support testing both `push` and `pull_request` events.
- Upload test logs as GitHub artifacts for easier debugging.

### Why this is needed
Previously, the CI workflow only built StarryOS but did not run automated tests.
This update enables real boot testing on QEMU through the official starry-test-harness,
ensuring CI correctness for aarch64 and improving test coverage.

### Test results
- CI passes on aarch64 build + boot test.
- Test harness successfully boots StarryOS into BusyBox shell.
 from https://github.com/yeanwang666/StarryOS/tree/fix by @yeanwang666  @sunhaosheng 