### PR TITLE
fix: implement signalfd

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,29 @@
+# Automatically detect text files and normalize line endings to LF
+* text=auto eol=lf
+
+# Explicitly specify text files
+*.rs text eol=lf
+*.toml text eol=lf
+*.md text eol=lf
+*.sh text eol=lf
+*.py text eol=lf
+*.json text eol=lf
+*.yaml text eol=lf
+*.yml text eol=lf
+*.txt text eol=lf
+*.c text eol=lf
+*.h text eol=lf
+*.cpp text eol=lf
+*.hpp text eol=lf
+
+# Binary files
+*.bin binary
+*.elf binary
+*.img binary
+*.dbg binary
+*.swp binary
+*.swo binary
+
+# Script files (keep executable)
+*.sh text eol=lf
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ axplat-loongarch64-qemu-virt = { git = "https://github.com/Starry-OS/axplat_crat
 page_table_entry = { git = "https://github.com/Starry-OS/page_table_multiarch.git", rev = "9df46c8" }
 page_table_multiarch = { git = "https://github.com/Starry-OS/page_table_multiarch.git", rev = "9df46c8" }
 starry-process = { git = "https://github.com/Starry-OS/starry-process.git", rev = "6327455" }
-starry-signal = { git = "https://github.com/Starry-OS/starry-signal.git", rev = "5b23dec" }
+starry-signal = { git = "https://github.com/Starry-OS/starry-signal.git", rev = "acdb5e9" }
 starry-vm = { git = "https://github.com/Starry-OS/starry-vm.git", rev = "4c91a6b" }
 
 [package.metadata.vendor-filter]

--- a/api/src/file/mod.rs
+++ b/api/src/file/mod.rs
@@ -4,6 +4,7 @@ mod fs;
 mod net;
 mod pidfd;
 mod pipe;
+pub mod signalfd;
 
 use alloc::{borrow::Cow, sync::Arc};
 use core::{any::Any, ffi::c_int, time::Duration};

--- a/api/src/file/signalfd.rs
+++ b/api/src/file/signalfd.rs
@@ -1,0 +1,188 @@
+use alloc::{borrow::Cow, sync::Arc};
+use core::{
+    any::Any,
+    mem,
+    sync::atomic::{AtomicBool, Ordering},
+    task::Context,
+};
+
+use axerrno::{AxError, AxResult};
+use axio::{BufMut, Write};
+use axpoll::{IoEvents, PollSet, Pollable};
+use axtask::{current, future::Poller};
+use starry_core::task::AsThread;
+use starry_signal::{SignalInfo, SignalSet};
+use spin::RwLock;
+use zerocopy::{Immutable, IntoBytes};
+
+use crate::file::{FileLike, Kstat, SealedBufMut};
+
+/// The size of signalfd_siginfo structure (128 bytes as per Linux specification)
+const SIGNALFD_SIGINFO_SIZE: usize = 128;
+
+/// signalfd_siginfo structure layout
+/// This matches the Linux signalfd_siginfo structure (128 bytes)
+#[repr(C)]
+#[derive(Immutable, IntoBytes)]
+struct SignalfdSiginfo {
+    ssi_signo: u32,      // Signal number
+    ssi_errno: i32,      // Error number (unused)
+    ssi_code: i32,       // Signal code
+    ssi_pid: u32,        // PID of sender
+    ssi_uid: u32,        // Real UID of sender
+    ssi_fd: i32,         // File descriptor (SIGIO)
+    ssi_tid: u32,        // Kernel timer ID (POSIX timers)
+    ssi_band: u32,       // Band event (SIGIO)
+    ssi_overrun: u32,    // POSIX timer overrun count
+    ssi_trapno: u32,     // Trap number that caused signal
+    ssi_status: i32,     // Exit status or signal (SIGCHLD)
+    ssi_int: i32,        // Integer sent by sigqueue(2)
+    ssi_ptr: u64,        // Pointer sent by sigqueue(2)
+    ssi_utime: u64,      // User CPU time consumed (SIGCHLD)
+    ssi_stime: u64,      // System CPU time consumed (SIGCHLD)
+    ssi_addr: u64,       // Address that generated signal
+    ssi_addr_lsb: u16,   // Least significant bit of address
+    _pad: [u8; 46],      // Padding to make it 128 bytes
+}
+
+const _: [(); SIGNALFD_SIGINFO_SIZE] = [(); mem::size_of::<SignalfdSiginfo>()];
+
+impl SignalfdSiginfo {
+    /// Convert from SignalInfo to signalfd_siginfo
+    fn from_signal_info(sig_info: &SignalInfo) -> Self {
+        let errno = sig_info.errno();
+
+        SignalfdSiginfo {
+            ssi_signo: sig_info.signo() as u32,
+            ssi_errno: errno,
+            ssi_code: sig_info.code(),
+            ssi_pid: 0,
+            ssi_uid: 0,
+            ssi_fd: -1,
+            ssi_tid: 0,
+            ssi_band: 0,
+            ssi_overrun: 0,
+            ssi_trapno: 0,
+            ssi_status: 0,
+            ssi_int: 0,
+            ssi_ptr: 0,
+            ssi_utime: 0,
+            ssi_stime: 0,
+            ssi_addr: 0,
+            ssi_addr_lsb: 0,
+            _pad: [0u8; 46],
+        }
+    }
+}
+
+pub struct Signalfd {
+    mask: RwLock<SignalSet>,
+    non_blocking: AtomicBool,
+    poll_rx: PollSet,
+}
+
+impl Signalfd {
+    pub fn new(mask: SignalSet) -> Arc<Self> {
+        Arc::new(Self {
+            mask: RwLock::new(mask),
+            non_blocking: AtomicBool::new(false),
+            poll_rx: PollSet::new(),
+        })
+    }
+
+    pub fn update_mask(&self, mask: SignalSet) {
+        *self.mask.write() = mask;
+        self.poll_rx.wake();
+    }
+
+    fn mask(&self) -> SignalSet {
+        *self.mask.read()
+    }
+
+    /// Check if there are any pending signals matching the mask
+    fn has_pending_signals(&self) -> bool {
+        let mask = self.mask();
+        let curr = current();
+        let signal = &curr.as_thread().signal;
+        let pending = signal.pending();
+        !(pending & mask).is_empty()
+    }
+
+    /// Dequeue a signal matching the mask
+    fn dequeue_signal(&self) -> Option<SignalInfo> {
+        let mask = self.mask();
+        let curr = current();
+        let signal = &curr.as_thread().signal;
+        signal.dequeue_signal(&mask)
+    }
+}
+
+impl FileLike for Signalfd {
+    fn read(&self, dst: &mut SealedBufMut) -> AxResult<usize> {
+        if dst.remaining_mut() < SIGNALFD_SIGINFO_SIZE {
+            return Err(AxError::InvalidInput);
+        }
+
+        Poller::new(self, IoEvents::IN)
+            .non_blocking(self.nonblocking())
+            .poll(|| {
+                if let Some(sig_info) = self.dequeue_signal() {
+                    // Convert SignalInfo to SignalfdSiginfo
+                    let sfd_info = SignalfdSiginfo::from_signal_info(&sig_info);
+                    
+                    // Write the structure to the destination buffer
+                    let bytes = sfd_info.as_bytes();
+                    dst.write(bytes)?;
+                    
+                    // Wake up other waiters if there are more signals pending
+                    if self.has_pending_signals() {
+                        self.poll_rx.wake();
+                    }
+                    
+                    Ok(SIGNALFD_SIGINFO_SIZE)
+                } else {
+                    Err(AxError::WouldBlock)
+                }
+            })
+    }
+
+    fn write(&self, _src: &mut crate::file::SealedBuf) -> AxResult<usize> {
+        // signalfd is read-only
+        Err(AxError::BadFileDescriptor)
+    }
+
+    fn stat(&self) -> AxResult<Kstat> {
+        Ok(Kstat::default())
+    }
+
+    fn nonblocking(&self) -> bool {
+        self.non_blocking.load(Ordering::Acquire)
+    }
+
+    fn set_nonblocking(&self, non_blocking: bool) -> AxResult {
+        self.non_blocking.store(non_blocking, Ordering::Release);
+        Ok(())
+    }
+
+    fn path(&self) -> Cow<str> {
+        "anon_inode:[signalfd]".into()
+    }
+
+    fn into_any(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
+    }
+}
+
+impl Pollable for Signalfd {
+    fn poll(&self) -> IoEvents {
+        let mut events = IoEvents::empty();
+        events.set(IoEvents::IN, self.has_pending_signals());
+        events
+    }
+
+    fn register(&self, context: &mut Context<'_>, events: IoEvents) {
+        if events.contains(IoEvents::IN) {
+            self.poll_rx.register(context.waker());
+        }
+    }
+}

--- a/api/src/syscall/fs/mod.rs
+++ b/api/src/syscall/fs/mod.rs
@@ -6,8 +6,9 @@ mod memfd;
 mod mount;
 mod pidfd;
 mod pipe;
+mod signalfd;
 mod stat;
 
 pub use self::{
-    ctl::*, event::*, fd_ops::*, io::*, memfd::*, mount::*, pidfd::*, pipe::*, stat::*,
+    ctl::*, event::*, fd_ops::*, io::*, memfd::*, mount::*, pidfd::*, pipe::*, signalfd::*, stat::*,
 };

--- a/api/src/syscall/fs/signalfd.rs
+++ b/api/src/syscall/fs/signalfd.rs
@@ -1,0 +1,71 @@
+use axerrno::{AxError, AxResult};
+use bitflags::bitflags;
+use linux_raw_sys::general::{O_CLOEXEC, O_NONBLOCK};
+use starry_signal::SignalSet;
+use starry_vm::VmPtr;
+
+use crate::{
+    file::{signalfd::Signalfd, add_file_like, FileLike},
+    syscall::signal::check_sigset_size,
+};
+
+// SFD flag definitions (if not available in linux_raw_sys)
+const SFD_CLOEXEC: u32 = O_CLOEXEC;
+const SFD_NONBLOCK: u32 = O_NONBLOCK;
+
+bitflags! {
+    /// Flags for the `signalfd4` syscall.
+    #[derive(Debug, Clone, Copy, Default)]
+    pub struct SignalfdFlags: u32 {
+        /// Create a file descriptor that is closed on `exec`.
+        const CLOEXEC = SFD_CLOEXEC;
+        /// Create a non-blocking signalfd.
+        const NONBLOCK = SFD_NONBLOCK;
+    }
+}
+
+/// signalfd4 system call
+/// 
+/// Creates a file descriptor that can be used to accept signals targeted at
+/// the caller. This provides an alternative to the use of a signal handler or
+/// sigwaitinfo(2), and has the advantage that the file descriptor may be
+/// monitored by select(2), poll(2), and epoll(7).
+/// 
+/// # Arguments
+/// * `fd` - If `fd` is -1, then a new file descriptor is created. Otherwise,
+///   `fd` must specify a valid existing signalfd file descriptor.
+/// * `mask` - Pointer to a signal set (sigset_t).
+/// * `sigsetsize` - The size (in bytes) of the mask pointed to by `mask`.
+/// * `flags` - Flags to control the operation.
+pub fn sys_signalfd4(
+    fd: i32,
+    mask: *const SignalSet,
+    sigsetsize: usize,
+    flags: u32,
+) -> AxResult<isize> {
+    check_sigset_size(sigsetsize)?;
+
+    let flags = SignalfdFlags::from_bits(flags).ok_or(AxError::InvalidInput)?;
+
+    if fd != -1 && flags.contains(SignalfdFlags::CLOEXEC) {
+        return Err(AxError::InvalidInput);
+    }
+
+    // Read the signal mask from user space before handling the request mode.
+    let mask = unsafe { mask.vm_read_uninit()?.assume_init() };
+
+    // If fd is not -1, we should modify the existing signalfd
+    if fd != -1 {
+        let signalfd = Signalfd::from_fd(fd)?;
+        signalfd.update_mask(mask);
+        signalfd.set_nonblocking(flags.contains(SignalfdFlags::NONBLOCK))?;
+        return Ok(fd as _);
+    }
+
+    // Create a new Signalfd
+    let signalfd = Signalfd::new(mask);
+    signalfd.set_nonblocking(flags.contains(SignalfdFlags::NONBLOCK))?;
+
+    // Add to file descriptor table
+    add_file_like(signalfd as _, flags.contains(SignalfdFlags::CLOEXEC)).map(|fd| fd as _)
+}

--- a/api/src/syscall/mod.rs
+++ b/api/src/syscall/mod.rs
@@ -582,9 +582,16 @@ pub fn handle_syscall(uctx: &mut UserContext) {
             uctx.arg4() as _,
         ),
 
+        // signal file descriptors
+        Sysno::signalfd4 => sys_signalfd4(
+            uctx.arg0() as _,
+            uctx.arg1() as _,
+            uctx.arg2(),
+            uctx.arg3() as _,
+        ),
+
         // dummy fds
-        Sysno::signalfd4
-        | Sysno::timerfd_create
+        Sysno::timerfd_create
         | Sysno::fanotify_init
         | Sysno::inotify_init1
         | Sysno::userfaultfd


### PR DESCRIPTION
- Add Signalfd file descriptor implementation (api/src/file/signalfd.rs)
- Implement signalfd4 system call handler (api/src/syscall/fs/signalfd.rs)
- Register signalfd4 in syscall router (api/src/syscall/mod.rs)
- Export signalfd module in file/mod.rs and syscall/fs/mod.rs

This fixes the panic when reading from signalfd4 file descriptor. Previously, signalfd4 returned a DummyFd which would panic on read. Now it returns a proper Signalfd that can read signals correctly.

Fixes #15