### PR TITLE
fix: execve allow NULL argv and envp

### DIFF
--- a/api/src/syscall/task/execve.rs
+++ b/api/src/syscall/task/execve.rs
@@ -18,8 +18,8 @@ pub fn sys_execve(
 ) -> AxResult<isize> {
     let path = vm_load_string(path)?;
 
-    // Handle NULL argv (treat as empty array)
     let args = if argv.is_null() {
+        // Handle NULL argv (treat as empty array)
         Vec::new()
     } else {
         vm_load_until_nul(argv)?
@@ -28,8 +28,8 @@ pub fn sys_execve(
             .collect::<Result<Vec<_>, _>>()?
     };
 
-    // Handle NULL envp (treat as empty array)
     let envs = if envp.is_null() {
+        // Handle NULL envp (treat as empty array)
         Vec::new()
     } else {
         vm_load_until_nul(envp)?

--- a/api/src/syscall/task/execve.rs
+++ b/api/src/syscall/task/execve.rs
@@ -18,15 +18,25 @@ pub fn sys_execve(
 ) -> AxResult<isize> {
     let path = vm_load_string(path)?;
 
-    let args = vm_load_until_nul(argv)?
-        .into_iter()
-        .map(vm_load_string)
-        .collect::<Result<Vec<_>, _>>()?;
+    // Handle NULL argv (treat as empty array)
+    let args = if argv.is_null() {
+        Vec::new()
+    } else {
+        vm_load_until_nul(argv)?
+            .into_iter()
+            .map(vm_load_string)
+            .collect::<Result<Vec<_>, _>>()?
+    };
 
-    let envs = vm_load_until_nul(envp)?
-        .into_iter()
-        .map(vm_load_string)
-        .collect::<Result<Vec<_>, _>>()?;
+    // Handle NULL envp (treat as empty array)
+    let envs = if envp.is_null() {
+        Vec::new()
+    } else {
+        vm_load_until_nul(envp)?
+            .into_iter()
+            .map(vm_load_string)
+            .collect::<Result<Vec<_>, _>>()?
+    };
 
     debug!("sys_execve <= path: {path:?}, args: {args:?}, envs: {envs:?}");
 

--- a/api/src/terminal/ldisc.rs
+++ b/api/src/terminal/ldisc.rs
@@ -95,6 +95,7 @@ impl<R: TtyRead, W: TtyWrite> InputReader<R, W> {
                 *offset += read;
                 if *offset == self.line_buf.len() {
                     self.line_read = None;
+                    self.line_buf.clear();
                 }
                 continue;
             }


### PR DESCRIPTION
This PR is mean to solve issue #17 
The configuration process followed the original issue description, keeping only the spawn test.
- First, I located the implementation of the execve system call in StarryOS: execve.rs.
```c
TEST(posix_spawnp(&pid, "echo", &fa, 0, (char *[]){"echo","hello",0}, 0);
```
- The code above is from the libc test. Here, the environment variable parameter for spawn (which ultimately calls execve) is passed as 0.

- According to the POSIX standard, execve allows envp to be NULL (indicating an empty environment).
-  However, StarryOS's implementation did not handle this case and directly called vm_load_until_nul on the NULL pointer, resulting in an EFAULT (Bad Address) error.

- I checked the Linux execve implementation in QEMU and found that it checks if the pointer is NULL before processing envp.

- I added checks for both arg and env:
```rust
    // Handle NULL argv (treat as empty array)
    let args = if argv.is_null() {
        Vec::new()
    } else {
        vm_load_until_nul(argv)?
            .into_iter()
            .map(vm_load_string)
            .collect::<Result<Vec<_>, _>>()?
    };

    // Handle NULL envp (treat as empty array)
    let envs = if envp.is_null() {
        Vec::new()
    } else {
        vm_load_until_nul(envp)?
            .into_iter()
            .map(vm_load_string)
            .collect::<Result<Vec<_>, _>>()?
    };
```

tests are proved to get passed