### PR TITLE
feat: initial support for vDSO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@
 /mnt
 *.swp
 *.swo
-*.so

--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,4 @@
 /mnt
 *.swp
 *.swo
-
+*.so

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2127,6 +2127,7 @@ dependencies = [
  "starry-core",
  "starry-process",
  "starry-signal",
+ "starry-vdso",
 ]
 
 [[package]]
@@ -2177,6 +2178,7 @@ dependencies = [
  "starry-core",
  "starry-process",
  "starry-signal",
+ "starry-vdso",
  "starry-vm",
  "syscalls",
  "x86",
@@ -2187,6 +2189,7 @@ dependencies = [
 name = "starry-core"
 version = "0.1.0"
 dependencies = [
+ "axalloc",
  "axbacktrace",
  "axconfig",
  "axerrno",
@@ -2222,6 +2225,7 @@ dependencies = [
  "spin 0.10.0",
  "starry-process",
  "starry-signal",
+ "starry-vdso",
  "starry-vm",
  "strum",
  "uluru",
@@ -2255,6 +2259,11 @@ dependencies = [
  "starry-vm",
  "strum",
 ]
+
+[[package]]
+name = "starry-vdso"
+version = "0.1.0"
+source = "git+https://github.com/muou000/starry-vdso.git?rev=bf1aeba#bf1aebae859cac70df68c2f07ff3b0e0acce1a24"
 
 [[package]]
 name = "starry-vm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,8 @@ starry-process = "0.2"
 starry-signal = "0.2"
 starry-vm = "0.2"
 
+starry-vdso = "0.1.0"
+
 starry-core = { path = "./core" }
 starry-api = { path = "./api" }
 
@@ -139,6 +141,8 @@ starry-signal.workspace = true
 starry-core.workspace = true
 starry-api.workspace = true
 
+starry-vdso.workspace = true
+
 [dependencies.axplat-riscv64-visionfive2]
 git = "https://github.com/Starry-OS/axplat-riscv64-visionfive2.git"
 rev = "5056c1d"
@@ -160,6 +164,8 @@ page_table_multiarch = { git = "https://github.com/Starry-OS/page_table_multiarc
 starry-process = { git = "https://github.com/Starry-OS/starry-process.git", rev = "6327455" }
 starry-signal = { git = "https://github.com/Starry-OS/starry-signal.git", rev = "acdb5e9" }
 starry-vm = { git = "https://github.com/Starry-OS/starry-vm.git", rev = "4c91a6b" }
+
+starry-vdso = { git = "https://github.com/muou000/starry-vdso.git", rev = "bf1aeba"}
 
 [package.metadata.vendor-filter]
 platforms = ["riscv64gc-unknown-none-elf", "loongarch64-unknown-none-softfloat"]

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,6 @@ ifeq ($(MEMTRACK), y)
 	APP_FEATURES += starry-api/memtrack
 endif
 
-VDSO_URL = https://github.com/muou000/starry-vdso/releases/download/vdso
-VDSO = vdso_$(ARCH).so
-vdso:
-	@if [ ! -f $(VDSO) ]; then \
-		echo "VDSO not found, downloading..."; \
-		curl -f -L $(VDSO_URL)/$(VDSO) -O; \
-	fi
-	@cp $(VDSO) ./vdso.so
-
 IMG_URL = https://github.com/Starry-OS/rootfs/releases/download/20250917
 IMG = rootfs-$(ARCH).img
 
@@ -45,7 +36,6 @@ defconfig justrun clean:
 	@make -C arceos $@
 
 build run debug disasm: defconfig
-	@make vdso
 	@make -C arceos $@
 
 # Aliases

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,15 @@ ifeq ($(MEMTRACK), y)
 	APP_FEATURES += starry-api/memtrack
 endif
 
+VDSO_URL = https://github.com/muou000/starry-vdso/releases/download/vdso
+VDSO = vdso_$(ARCH).so
+vdso:
+	@if [ ! -f $(VDSO) ]; then \
+		echo "VDSO not found, downloading..."; \
+		curl -f -L $(VDSO_URL)/$(VDSO) -O; \
+	fi
+	@cp $(VDSO) ./vdso.so
+
 IMG_URL = https://github.com/Starry-OS/rootfs/releases/download/20250917
 IMG = rootfs-$(ARCH).img
 
@@ -36,6 +45,7 @@ defconfig justrun clean:
 	@make -C arceos $@
 
 build run debug disasm: defconfig
+	@make vdso
 	@make -C arceos $@
 
 # Aliases

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -60,6 +60,7 @@ spin.workspace = true
 starry-process.workspace = true
 starry-signal.workspace = true
 starry-vm.workspace = true
+starry-vdso.workspace = true
 syscalls = { git = "https://github.com/jasonwhite/syscalls.git", rev = "92624de", default-features = false }
 zerocopy = { version = "0.8.26", features = ["derive"] }
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -23,9 +23,6 @@ pub mod vfs;
 
 /// Initialize.
 pub fn init() {
-    if axconfig::plat::CPU_NUM > 1 {
-        panic!("SMP is not supported");
-    }
     info!("Initialize VFS...");
     vfs::mount_all().expect("Failed to mount vfs");
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -23,12 +23,19 @@ pub mod vfs;
 
 /// Initialize.
 pub fn init() {
+    if axconfig::plat::CPU_NUM > 1 {
+        panic!("SMP is not supported");
+    }
     info!("Initialize VFS...");
     vfs::mount_all().expect("Failed to mount vfs");
+
+    info!("Initialize vDSO data...");
+    starry_core::vdso::init_vdso_data();
 
     info!("Initialize /proc/interrupts...");
     axtask::register_timer_callback(|_| {
         time::inc_irq_cnt();
+        starry_core::vdso::update_vdso_data();
     });
 
     info!("Initialize alarm...");

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -8,6 +8,7 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
+axalloc.workspace = true
 axbacktrace.workspace = true
 axconfig.workspace = true
 axerrno.workspace = true
@@ -44,6 +45,7 @@ spin.workspace = true
 starry-process.workspace = true
 starry-signal.workspace = true
 starry-vm.workspace = true
+starry-vdso.workspace = true
 strum = { version = "0.27.2", default-features = false, features = ["derive"] }
 uluru = "3.1.0"
 weak-map = "0.1.1"

--- a/core/src/config/aarch64.rs
+++ b/core/src/config/aarch64.rs
@@ -21,3 +21,6 @@ pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
 pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+
+/// The number of VVAR pages.
+pub const VVAR_PAGES: usize = 5;

--- a/core/src/config/loongarch64.rs
+++ b/core/src/config/loongarch64.rs
@@ -21,3 +21,6 @@ pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
 pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+
+/// The number of VVAR pages.
+pub const VVAR_PAGES: usize = 44;

--- a/core/src/config/riscv64.rs
+++ b/core/src/config/riscv64.rs
@@ -21,3 +21,6 @@ pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
 pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+
+/// The number of VVAR pages.
+pub const VVAR_PAGES: usize = 2;

--- a/core/src/config/x86_64.rs
+++ b/core/src/config/x86_64.rs
@@ -21,3 +21,6 @@ pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
 pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+
+/// The number of VVAR pages.
+pub const VVAR_PAGES: usize = 4;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -18,3 +18,4 @@ pub mod shm;
 pub mod task;
 pub mod time;
 pub mod vfs;
+pub mod vdso;

--- a/core/src/vdso.rs
+++ b/core/src/vdso.rs
@@ -326,7 +326,7 @@ pub fn load_vdso_data(auxv: &mut Vec<AuxEntry>, uspace: &mut AddrSpace) -> AxRes
     };
     let page_off = (rnd() % (VDSO_ASLR_PAGES as u64)) as usize;
     let vdso_user_addr = VDSO_USER_ADDR_BASE + page_off * PAGE_SIZE_4K;
-    info!("vdso_kstart: {vdso_kstart}, vdso_kend: {vdso_kend}",);
+    info!("vdso_kstart: {vdso_kstart:#x}, vdso_kend: {vdso_kend:#x}",);
 
     if vdso_kend > vdso_kstart {
         let vdso_paddr = virt_to_phys(vdso_kstart.into());
@@ -413,12 +413,10 @@ pub fn load_vdso_data(auxv: &mut Vec<AuxEntry>, uspace: &mut AddrSpace) -> AxRes
 
     } else {
         warn!(
-            "vDSO binary is missing or invalid: vdso_kstart={:#x}, vdso_kend={:#x}. vDSO will not be loaded and AT_SYSINFO_EHDR will not be set.",
-            vdso_kstart, vdso_kend
-        );
+            "vDSO binary is missing or invalid: vdso_kstart={vdso_kstart:#x}, vdso_kend={vdso_kend:#x}. vDSO will not be loaded and AT_SYSINFO_EHDR will not be set.");
         return Err(AxError::InvalidExecutable);
     }
-    return Ok(());
+    Ok(())
 }
 
 fn mapping_flags(flags: xmas_elf::program::Flags) -> MappingFlags {


### PR DESCRIPTION
This pull request adds support for vDSO integration into the build process and runtime initialization. The main changes include automating the download of the vDSO binary, updating the initialization logic to handle vDSO data, and ensuring vDSO data is loaded into the user address space during ELF loading.

**Build process improvements:**

* Added a `vdso` make target to automatically download and copy the appropriate vDSO binary (`vdso_$(ARCH).so`) before building or running the project. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R24-R32) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R48)

**Runtime and initialization enhancements:**

* Updated the `init` function in `api/src/lib.rs` to initialize vDSO data and update it on timer interrupts, alongside existing VFS and alarm initialization.
* Added a new `vdso` module to `core/src/lib.rs` for managing vDSO functionality.

**User address space and ELF loading changes:**

* Integrated the `vdso` module into the memory management code (`core/src/mm.rs`), ensuring vDSO data is loaded into the auxiliary vector during ELF loading and user address space creation. [[1]](diffhunk://#diff-c51858dff4f4ccb2fd98726571b2f1e94168b2042b0cd07f6a22f11d14d33230L30-R30) [[2]](diffhunk://#diff-c51858dff4f4ccb2fd98726571b2f1e94168b2042b0cd07f6a22f11d14d33230L250-R255)

**TODO**

* Finish PVCLOCK update mode.
* Integrate rt_sigreturn from starry-signal into vDSO.