### PR TITLE
test: add signalfd user test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,6 +2039,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signalfd_test"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "simple-sdmmc"
 version = "0.1.0"
 source = "git+https://github.com/Starry-OS/simple-sdmmc.git?rev=db64be9#db64be91d8b5b0cae5c33f8e13e41a010233a306"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["api", "core"]
+members = ["api", "core", "signalfd_test"]
 exclude = ["arceos"]
 
 [workspace.package]

--- a/signalfd_test/.cargo/config.toml
+++ b/signalfd_test/.cargo/config.toml
@@ -1,0 +1,8 @@
+[target.riscv64gc-unknown-linux-musl]
+linker = "/opt/musl/riscv64-linux-musl-cross/bin/riscv64-linux-musl-gcc"
+rustflags = [
+    "-C", "target-feature=+crt-static",
+    "-C", "link-self-contained=yes",
+    "-C", "relocation-model=static",
+]
+

--- a/signalfd_test/Cargo.toml
+++ b/signalfd_test/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "signalfd_test"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+libc = "0.2"

--- a/signalfd_test/README.md
+++ b/signalfd_test/README.md
@@ -1,0 +1,37 @@
+## signalfd_test
+
+This crate is a tiny user-space program used to validate the fix for StarryOS issue
+[#15](https://github.com/Starry-OS/StarryOS/issues/15), where the `signalfd4` system
+call previously returned a dummy file descriptor that panicked on read.
+
+### Build
+
+```bash
+cargo build -p signalfd_test --release --target riscv64gc-unknown-linux-musl
+```
+
+The binary is statically linked when the `riscv64-linux-musl` toolchain is installed
+under `/opt/musl`. Adjust `CARGO_TARGET_*_LINKER` if your toolchain lives elsewhere.
+
+### Deploy into the StarryOS rootfs
+
+```bash
+sudo mount -o loop arceos/disk.img /mnt
+sudo cp target/riscv64gc-unknown-linux-musl/release/signalfd_test /mnt/root/
+sudo chmod +x /mnt/root/signalfd_test
+sudo umount /mnt
+```
+
+### Run inside QEMU
+
+```text
+make run
+# inside the guest shell
+starry:~# ./signalfd_test
+signalfd created: fd = 3
+read 128 bytes from signalfd
+```
+
+A successful run confirms that `signalfd4` now returns a real file descriptor backed
+by the kernel implementation, and that reading from it yields the expected
+128-byte `signalfd_siginfo` structure without panicking.

--- a/signalfd_test/src/main.rs
+++ b/signalfd_test/src/main.rs
@@ -1,0 +1,89 @@
+use std::{fs::File, io::{self, Read}, mem, os::unix::io::{FromRawFd, RawFd}, ptr};
+
+fn main() -> io::Result<()> {
+    let mask = unsafe { build_sigmask()? };
+    block_signals(&mask).map_err(|e| {
+        eprintln!("sigprocmask failed: {e}");
+        e
+    })?;
+    let fd = create_signalfd(&mask).map_err(|e| {
+        eprintln!("signalfd4 failed: {e}");
+        e
+    })?;
+    println!("signalfd created: fd = {fd}");
+
+    // 触发一个 SIGUSR1，确保 signalfd 有数据可读
+    send_signal(libc::SIGUSR1).map_err(|e| {
+        eprintln!("raise(SIGUSR1) failed: {e}");
+        e
+    })?;
+    read_signalfd(fd).map_err(|e| {
+        eprintln!("read(signalfd) failed: {e}");
+        e
+    })?;
+    Ok(())
+}
+
+unsafe fn build_sigmask() -> io::Result<libc::sigset_t> {
+    let mut mask: libc::sigset_t = mem::zeroed();
+    if libc::sigemptyset(&mut mask) != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    for sig in [libc::SIGUSR1, libc::SIGUSR2] {
+        if libc::sigaddset(&mut mask, sig) != 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(mask)
+}
+
+fn block_signals(mask: &libc::sigset_t) -> io::Result<()> {
+    let ret = unsafe { libc::sigprocmask(libc::SIG_BLOCK, mask, ptr::null_mut()) };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn create_signalfd(mask: &libc::sigset_t) -> io::Result<RawFd> {
+    let candidates = [mem::size_of::<libc::sigset_t>(), 0];
+    let mut last_err = None;
+    for &sigset_size in &candidates {
+        let fd = unsafe {
+            libc::syscall(
+                libc::SYS_signalfd4,
+                -1i32,
+                mask as *const libc::sigset_t,
+                sigset_size,
+                libc::SFD_CLOEXEC,
+            ) as RawFd
+        };
+        if fd >= 0 {
+            return Ok(fd);
+        }
+        let err = io::Error::last_os_error();
+        if err.kind() != io::ErrorKind::InvalidInput {
+            return Err(err);
+        }
+        last_err = Some(err);
+    }
+    Err(last_err.unwrap_or_else(io::Error::last_os_error))
+}
+
+fn send_signal(sig: libc::c_int) -> io::Result<()> {
+    let ret = unsafe { libc::raise(sig) };
+    if ret != 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+fn read_signalfd(fd: RawFd) -> io::Result<()> {
+    let mut file = unsafe { File::from_raw_fd(fd) };
+    let mut buffer = [0u8; 128];
+    match file.read(&mut buffer) {
+        Ok(n) => println!("read {n} bytes from signalfd"),
+        Err(e) => return Err(e),
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add a new workspace member signalfd_test, a tiny user-space program that reproduces the scenario described in issue #15 (signalfd4 returning a dummy FD and panicking on read).
- The test blocks SIGUSR1/SIGUSR2, creates a signalfd via signalfd4(-1, mask, sizeof(sigset_t), SFD_CLOEXEC), raises SIGUSR1 and reads 128 bytes of signalfd_siginfo.
- The binary is cross-compiled for riscv64gc-unknown-linux-musl, fully statically linked, and copied into the StarryOS rootfs.

## Testing
Steps to run manually:
1. `cargo build -p signalfd_test --release --target riscv64gc-unknown-linux-musl`
2. Copy the resulting `target/riscv64gc-unknown-linux-musl/release/signalfd_test` into `arceos/disk.img` (e.g., `/root/signalfd_test`) and `chmod +x`.
3. `make run` to boot StarryOS in QEMU.
4. In the guest shell:
```sh
   starry:~# ./signalfd_test
   signalfd created: fd = 3
   read 128 bytes from signalfd
```
This confirms that the kernel-side fix for issue #15 works as expected and no longer panics.