### PR TITLE
chore: update syscalls crate to 0.7.0 with loongarch64 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2322,8 +2322,8 @@ dependencies = [
 
 [[package]]
 name = "syscalls"
-version = "0.6.18"
-source = "git+https://github.com/jasonwhite/syscalls.git?rev=92624de#92624de3dee33427fde46da083809d7e86a721ec"
+version = "0.7.0"
+source = "git+https://github.com/Starry-OS/syscalls.git?rev=efac241add625e84379607e5da643bbe34b28190#efac241add625e84379607e5da643bbe34b28190"
 
 [[package]]
 name = "thiserror"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -60,7 +60,7 @@ spin.workspace = true
 starry-process.workspace = true
 starry-signal.workspace = true
 starry-vm.workspace = true
-syscalls = { git = "https://github.com/jasonwhite/syscalls.git", rev = "92624de", default-features = false }
+syscalls = { git = "https://github.com/Starry-OS/syscalls.git", rev = "efac241add625e84379607e5da643bbe34b28190", default-features = false }
 zerocopy = { version = "0.8.26", features = ["derive"] }
 
 starry-core.workspace = true

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -60,7 +60,7 @@ spin.workspace = true
 starry-process.workspace = true
 starry-signal.workspace = true
 starry-vm.workspace = true
-syscalls = { git = "https://github.com/Starry-OS/syscalls.git", rev = "efac241add625e84379607e5da643bbe34b28190", default-features = false }
+syscalls = { git = "https://github.com/Starry-OS/syscalls.git", rev = "efac241", default-features = false }
 zerocopy = { version = "0.8.26", features = ["derive"] }
 
 starry-core.workspace = true


### PR DESCRIPTION
update syscalls dependency to https://github.com/Starry-OS/syscalls.git

Fixes #7 