### PR TITLE
[WIP] feat/process state management

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,11 @@
 	path = arceos
 	url = https://github.com/Starry-OS/arceos
 	branch = main
+[submodule "local_crates/starry-signal"]
+	path = local_crates/starry-signal
+	url = https://github.com/TomGoh/starry-signal.git
+	branch = feat/sigstop-cont
+[submodule "local_crates/starry-process"]
+	path = local_crates/starry-process
+	url = https://github.com/TomGoh/starry-process.git
+	branch = feat/state-machine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1036,6 +1036,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "ctor"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec09e802f5081de6157da9a75701d6c713d8dc3ba52571fd4bd25f412644e8a6"
+dependencies = [
+ "ctor-proc-macro",
+ "dtor",
+]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2931af7e13dc045d8e9d26afccc6fa115d64e115c9c84b1166288b46f6782c2"
+
+[[package]]
 name = "darling"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1148,21 @@ dependencies = [
  "syn 2.0.111",
  "unicode-xid",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97cbdf2ad6846025e8e25df05171abfb30e3ababa12ee0a0e44b9bbe570633a8"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7454e41ff9012c00d53cf7f475c5e3afa3b91b7c90568495495e8d9bf47a1055"
 
 [[package]]
 name = "either"
@@ -2248,9 +2279,9 @@ dependencies = [
 [[package]]
 name = "starry-process"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88fa031a95c25b7bcfe8883f9f53238c9053a2a89f790bb1a7c35d080c6d3b65"
 dependencies = [
+ "bitflags 2.10.0",
+ "ctor",
  "kspin",
  "lazyinit",
  "weak-map",
@@ -2259,7 +2290,6 @@ dependencies = [
 [[package]]
 name = "starry-signal"
 version = "0.2.3"
-source = "git+https://github.com/Starry-OS/starry-signal.git?tag=dev-v02#0597c1695b7c724f6d40e0d5873eaa148679e8bd"
 dependencies = [
  "axcpu",
  "bitflags 2.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,8 +72,8 @@ memory_addr = "0.4"
 scope-local = "0.1"
 slab = { version = "0.4.9", default-features = false }
 spin = "0.10"
-starry-process = "0.2"
-starry-signal = { version = "0.2", git = "https://github.com/Starry-OS/starry-signal.git", tag = "dev-v02" }
+starry-process = { path = "./local_crates/starry-process" }
+starry-signal = { path = "./local_crates/starry-signal" }
 starry-vm = "0.2"
 
 starry-core = { path = "./core" }

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Build Options
-export ARCH := riscv64
+export ARCH := aarch64
 export LOG := warn
 export BACKTRACE := y
 export MEMTRACK := n

--- a/api/src/signal.rs
+++ b/api/src/signal.rs
@@ -4,22 +4,79 @@ use axerrno::AxResult;
 use axhal::uspace::UserContext;
 use axtask::current;
 use starry_core::task::{AsThread, Thread};
-use starry_signal::{SignalOSAction, SignalSet};
+use starry_signal::{SignalOSAction, SignalSet, Signo};
 
-use crate::task::do_exit;
+use crate::task::{do_continue, do_exit, do_stop};
 
 pub fn check_signals(
     thr: &Thread,
     uctx: &mut UserContext,
     restore_blocked: Option<SignalSet>,
 ) -> bool {
+    // Per POSIX.1-2024, when SIGCONT is sent to a stopped process:
+    // 1. The process MUST continue (transition from STOPPED to RUNNING), even if:
+    //    - SIGCONT is blocked by all threads
+    //    - SIGCONT disposition is SIG_IGN (ignored)
+    //    - SIGCONT has a custom handler registered
+    // 2. The signal remains pending if blocked (delivered when unblocked later)
+    // 3. The handler executes after continuation (if not ignored)
+    //
+    // This pre-check ensures the side effect (continuing) happens before signal
+    // delivery as a must, which may be deferred if the signal is blocked.
+    //
+    // We only check with `has_signal()`, not `dequeue_signal()`, because blocked
+    // signals won't be dequeued but must still trigger the continue operation.
+    if thr.proc_data.proc.is_stopped() {
+        if thr.signal.has_signal(Signo::SIGCONT) || thr.proc_data.signal.has_signal(Signo::SIGCONT)
+        {
+            info!(
+                "Process {} continuing due to pending SIGCONT (may be blocked)",
+                thr.proc_data.proc.pid()
+            );
+            do_continue();
+        }
+    }
+
+    // A side effect of `check_signals` here woould be:
+    // if the signal is unblocked, it would be removed from the thread-level signal
+    // queue, and the signal would be handled following.
     let Some((sig, os_action)) = thr.signal.check_signals(uctx, restore_blocked) else {
         return false;
     };
 
     let signo = sig.signo();
+
+    // Special case:
+    // SIGCONT with ignored disposition.
+    // `os_action` is None, but we still need to continue.
+    // Since the `do_continue` is called initially, we may safely return.
+    if signo == Signo::SIGCONT && os_action.is_none() {
+        info!(
+            "Process {} continuing due to ignored SIGCONT with stopped: {}",
+            thr.proc_data.proc.pid(),
+            thr.proc_data.proc.is_stopped()
+        );
+
+        return true;
+    }
+
+    // Handle normal signals with OS actions
+    let Some(os_action) = os_action else {
+        // This shouldn't happen for other signals, but handle gracefully
+        warn!(
+            "Process {} received signal {} with no OS action",
+            thr.proc_data.proc.pid(),
+            signo as u8
+        );
+        return false;
+    };
+
     match os_action {
         SignalOSAction::Terminate => {
+            info!(
+                "Process {} terminating due to signal",
+                thr.proc_data.proc.pid()
+            );
             do_exit(signo as i32, true);
         }
         SignalOSAction::CoreDump => {
@@ -27,14 +84,17 @@ pub fn check_signals(
             do_exit(128 + signo as i32, true);
         }
         SignalOSAction::Stop => {
-            // TODO: implement stop
-            do_exit(1, true);
+            info!("Process {} stopped due to signal", thr.proc_data.proc.pid());
+            do_stop(signo);
         }
         SignalOSAction::Continue => {
-            // TODO: implement continue
+            info!(
+                "Process {} continuing due to signal (handled by pre-check)",
+                thr.proc_data.proc.pid()
+            );
         }
         SignalOSAction::Handler => {
-            // do nothing
+            info!("Process {} handling signal", thr.proc_data.proc.pid());
         }
     }
     true

--- a/api/src/syscall/task/clone.rs
+++ b/api/src/syscall/task/clone.rs
@@ -180,6 +180,7 @@ pub fn sys_clone(
             aspace,
             signal_actions,
             exit_signal,
+            None,
         );
         proc_data.set_umask(old_proc_data.umask());
 

--- a/api/src/syscall/task/clone.rs
+++ b/api/src/syscall/task/clone.rs
@@ -180,7 +180,6 @@ pub fn sys_clone(
             aspace,
             signal_actions,
             exit_signal,
-            None,
         );
         proc_data.set_umask(old_proc_data.umask());
 

--- a/api/src/task.rs
+++ b/api/src/task.rs
@@ -1,8 +1,8 @@
-use core::{ffi::c_long, sync::atomic::Ordering};
+use core::{ffi::c_long, future::poll_fn, sync::atomic::Ordering, task::Poll};
 
 use axerrno::{AxError, AxResult};
 use axhal::uspace::{ExceptionKind, ReturnReason, UserContext};
-use axtask::{TaskInner, current};
+use axtask::{CurrentTask, TaskInner, current, future::block_on};
 use bytemuck::AnyBitPattern;
 use linux_raw_sys::general::ROBUST_LIST_LIMIT;
 use starry_core::{
@@ -10,8 +10,8 @@ use starry_core::{
     mm::access_user_memory,
     shm::SHM_MANAGER,
     task::{
-        AsThread, get_process_data, get_task, send_signal_to_process, send_signal_to_thread,
-        set_timer_state,
+        AsThread, Thread, get_process_data, get_task, send_signal_to_process,
+        send_signal_to_thread, set_timer_state,
     },
     time::TimerState,
 };
@@ -85,6 +85,20 @@ pub fn new_user_task(
                     }
                 }
 
+                // Check for a potential stop signal
+                if !unblock_next_signal() {
+                    while check_signals(thr, &mut uctx, None) {}
+                }
+
+                // Handle the stop signal if any
+                handle_stopped_state(&curr, thr);
+
+                // Check for potential continue or kill signal
+                // after a `Ready` result is returned from the helper
+                // function handling the potential stopped state.
+                // This time, the state of the process may be
+                // set to be `Running` if it was previously stopped
+                // in the `do_continue` function within `check_signals`.
                 if !unblock_next_signal() {
                     while check_signals(thr, &mut uctx, None) {}
                 }
@@ -224,4 +238,181 @@ pub fn raise_signal_fatal(sig: SignalInfo) -> AxResult<()> {
     }
 
     Ok(())
+}
+
+/// Handle the potential stopped state of the current process,
+/// actually performing the stoppage.
+///
+/// The procedure is as follows:
+/// 1. Check if the process is stopped.
+/// 2. If the process is not stopped, return.
+/// 3. If the process is stopped, block until continued.
+///
+/// How this
+fn handle_stopped_state(curr: &CurrentTask, thr: &Thread) {
+    // Check if process is stopped and block until continued.
+    // If the process is not in the stopped state, return.
+    // The stopped state should have already been set
+    // if there is a signal that requests to stop the process
+    // in the previous `check_signals` function call with
+    // `do_stop` function in the stopped branch.
+    if !thr.proc_data.proc.is_stopped() {
+        return;
+    }
+
+    info!(
+        "Task {} blocked (process {} stopped)",
+        curr.id().as_u64(),
+        thr.proc_data.proc.pid()
+    );
+
+    // Deploy an async event for actually stopping the process
+    block_on(poll_fn(|cx| {
+        // Only return `Ready` when the stopped state has been updated to other states
+        if !thr.proc_data.proc.is_stopped() {
+            Poll::Ready(())
+        } else {
+            // This won't got executed when process is stopped until a
+            // SIGCONT or SIGKILL arrives, which would change the process state
+            info!(
+                "Task {} blocked (process {} stopped), checking signals",
+                curr.id().as_u64(),
+                thr.proc_data.proc.pid()
+            );
+            if thr.signal.has_signal(Signo::SIGCONT)
+                || thr.signal.has_signal(Signo::SIGKILL)
+                || thr.proc_data.signal.has_signal(Signo::SIGCONT)
+                || thr.proc_data.signal.has_signal(Signo::SIGKILL)
+            {
+                info!(
+                    "Task {} blocked (process {} stopped), signal received",
+                    curr.id().as_u64(),
+                    thr.proc_data.proc.pid()
+                );
+                return Poll::Ready(());
+            }
+
+            info!(
+                "Task {} blocked (process {} stopped), waiting for signal",
+                curr.id().as_u64(),
+                thr.proc_data.proc.pid()
+            );
+
+            // Register the waker for a `stop_event`
+            thr.proc_data.stop_event.register(cx.waker());
+            Poll::Pending
+        }
+    }));
+
+    info!(
+        "Task {} resumed (process {} continued)",
+        curr.id().as_u64(),
+        thr.proc_data.proc.pid()
+    );
+}
+/// Stop the current process per a stopping signal.
+///
+/// Several procedures are involved in this function:
+/// 1. Remove all SIGCONT signals pending in the process's queue.
+/// 2. Remove all SIGCONT signals pending in each thread's queue.
+/// 3. Record the stop signal in `ProcessData`.
+/// 4. Change the state of current process to `STOPPED`.
+/// 5. Notify parent process for this stoppage state change.
+///
+/// # Arguments
+///
+/// * `stop_signal` - The signal that causes the process to stop.
+pub(crate) fn do_stop(stop_signal: Signo) {
+    let curr = current();
+    let curr_thread = curr.as_thread();
+    let curr_process = &curr_thread.proc_data.proc;
+
+    // If current process is not running, do nothing.
+    if !curr_process.is_running() {
+        warn!("Process {} is not running", curr_process.pid());
+        return;
+    }
+
+    info!(
+        "Process {} stopping due to signal {}",
+        curr_process.pid(),
+        stop_signal as u8
+    );
+
+    // remove all SIGCONT signals pending in the process's queue
+    curr_thread.proc_data.signal.remove_signal(Signo::SIGCONT);
+
+    // remove all SIGCONT signals pending in each thread's queue
+    curr_process.threads().iter().for_each(|tid| {
+        if let Ok(thread) = get_task(*tid) {
+            thread.as_thread().signal.remove_signal(Signo::SIGCONT);
+        }
+    });
+
+    // record the stop signal in `ProcessData`
+    *curr_thread.proc_data.stop_signal.write() = Some(stop_signal);
+
+    // change the state of current process to `STOPPED`
+    curr_process.transition_to_stopped();
+
+    // notify parent process for this stoppage state change
+    if let Some(parent) = curr_process.parent()
+        && let Ok(parent_data) = get_process_data(parent.pid())
+    {
+        parent_data.child_exit_event.wake();
+
+        // POSIX: Send SIGCHLD to parent when child stops (unless SA_NOCLDSTOP set)
+        // TODO: Check SA_NOCLDSTOP flag when implemented
+        let siginfo = SignalInfo::new_kernel(Signo::SIGCHLD);
+        let _ = send_signal_to_process(parent.pid(), Some(siginfo));
+    }
+}
+
+/// Continue the current process per a `SIGCONT` signal.
+///
+/// The procedure is as follows:
+/// 1. Remove all stopping signals pending in the process's queue.
+/// 2. Remove all stopping signals pending in each thread's queue.
+/// 3. Change the state of current process to `RUNNING`.
+/// 4. Resume all threads in the process.
+/// 5. Notify parent process for this stoppage state change.
+pub(crate) fn do_continue() {
+    let curr = current();
+    let curr_thread = curr.as_thread();
+    let curr_proc = &curr_thread.proc_data.proc;
+
+    // If current process is not stopped, do nothing.
+    if !curr_proc.is_stopped() {
+        warn!("Process {} is not stopped", curr_proc.pid());
+        return;
+    }
+
+    info!("Process {} continuing due to signal", curr_proc.pid());
+
+    // remove all stopping signals pending in the process's queue
+    curr_thread.proc_data.signal.flush_stop_signals();
+
+    // remove all stopping signals pending in each thread's queue
+    for thread_pid in curr_proc.threads().iter() {
+        if let Ok(thread) = get_task(*thread_pid) {
+            thread.as_thread().signal.flush_stop_signals();
+        }
+    }
+
+    // change the state of current process to `RUNNING`
+    curr_proc.transition_to_running();
+
+    // wake up all threads
+    for thread_pid in curr_proc.threads().iter() {
+        if let Ok(thread) = get_task(*thread_pid) {
+            thread.interrupt();
+        }
+    }
+
+    // Notify parent process for this continuation state change
+    if let Some(parent) = curr_proc.parent()
+        && let Ok(parent_data) = get_process_data(parent.pid())
+    {
+        parent_data.child_exit_event.wake();
+    }
 }

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -477,6 +477,14 @@ pub fn set_timer_state(task: &TaskInner, state: TimerState) {
 }
 
 fn send_signal_thread_inner(task: &TaskInner, thr: &Thread, sig: SignalInfo) {
+    let signo = sig.signo();
+
+    // Wake the process up, if it is stopped, i.e. blocked on the `stop_event`,
+    // when a SIGCONT or a SIGKILL arrives
+    if signo == Signo::SIGCONT || signo == Signo::SIGKILL {
+        thr.proc_data.stop_event.wake();
+    }
+
     if thr.signal.send_signal(sig) {
         task.interrupt();
     }

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -217,10 +217,13 @@ pub struct ProcessData {
     pub exit_event: Arc<PollSet>,
     /// Self stop event
     pub stop_event: Arc<PollSet>,
-    /// The exit signal of the thread
+    /// The signal to be sent to the parent process when this task terminates.
+    ///
+    /// - For normal processes (fork), this is usually `SIGCHLD`.
+    /// - For threads (clone with CLONE_THREAD), this is usually `None` (0).
+    ///
+    /// NOTE: This is NOT the signal that caused the task to exit.
     pub exit_signal: Option<Signo>,
-    /// The stop signal of the thread
-    pub stop_signal: RwLock<Option<Signo>>,
 
     /// The process signal manager
     pub signal: Arc<ProcessSignalManager>,
@@ -241,7 +244,6 @@ impl ProcessData {
         aspace: Arc<Mutex<AddrSpace>>,
         signal_actions: Arc<SpinNoIrq<SignalActions>>,
         exit_signal: Option<Signo>,
-        stop_signal: Option<Signo>,
     ) -> Arc<Self> {
         Arc::new(Self {
             proc,
@@ -258,7 +260,6 @@ impl ProcessData {
             exit_event: Arc::default(),
             stop_event: Arc::default(),
             exit_signal,
-            stop_signal: RwLock::new(stop_signal),
 
             signal: Arc::new(ProcessSignalManager::new(
                 signal_actions,

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -52,6 +52,7 @@ pub fn run_initproc(args: &[String], envs: &[String]) -> i32 {
         Arc::new(Mutex::new(uspace)),
         Arc::default(),
         None,
+        None,
     );
     {
         let mut scope = proc_data.scope.write();

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -52,7 +52,6 @@ pub fn run_initproc(args: &[String], envs: &[String]) -> i32 {
         Arc::new(Mutex::new(uspace)),
         Arc::default(),
         None,
-        None,
     );
     {
         let mut scope = proc_data.scope.write();


### PR DESCRIPTION
## Changes

- add `stop_event` and `stop_signal` in `ProcessData` to support process stopping, update relative initialization
- implement `do_continue` and `do_stop` function for process continuation and stoppage in `api/src/task.rs`
- implement `handle_stopped_state ` function to actually use the Poll mechanism implement stopping for processes in `api/src/task.rs`
- update `check_signals` function in `api/src/signal.rs` to check for SIGCONT under different scenarios, ensure the continuation of a stopped process regardless its signal mask and disposition settings
- update `check_signals` function in `api/src/signal.rs` to call `do_stop` and `do_continue` to respond to the signal.

## Related

- https://github.com/Starry-OS/starry-process/pull/5
- https://github.com/Starry-OS/starry-signal/pull/6