### PR TITLE
feat: add netlink route support and misc fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ linux-raw-sys = { version = "0.11", default-features = false, features = [
     "net",
     "prctl",
     "system",
+    "netlink",
 ] }
 memory_addr = "0.4"
 scope-local = "0.1"
@@ -97,6 +98,9 @@ qemu = [
 
     "axfeat/vsock",
     "starry-api/vsock",
+
+    "axfeat/netlink",
+    "starry-api/netlink",
 
     "axfeat/defplat",
     "axfeat/bus-pci",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 input = ["dep:axinput"]
 memtrack = ["axfeat/dwarf", "axalloc/tracking", "dep:gimli"]
 vsock = ["axnet/vsock"]
+netlink = ["axnet/netlink"]
 dev-log = []
 
 [dependencies]

--- a/api/src/file/mod.rs
+++ b/api/src/file/mod.rs
@@ -320,6 +320,22 @@ pub fn close_file_like(fd: c_int) -> AxResult {
     Ok(())
 }
 
+pub fn get_cloexec(fd: c_int) -> AxResult<bool> {
+    FD_TABLE
+        .read()
+        .get(fd as usize)
+        .ok_or(AxError::BadFileDescriptor)
+        .map(|fd| fd.cloexec)
+}
+
+pub fn set_cloexec(fd: c_int, cloexec: bool) -> AxResult {
+    FD_TABLE
+        .write()
+        .get_mut(fd as usize)
+        .ok_or(AxError::BadFileDescriptor)
+        .map(|fd| fd.cloexec = cloexec)
+}
+
 pub fn add_stdio(fd_table: &mut FlattenObjects<FileDescriptor, AX_FILE_LIMIT>) -> AxResult<()> {
     assert_eq!(fd_table.count(), 0);
     let cx = FS_CONTEXT.lock();

--- a/api/src/syscall/task/job.rs
+++ b/api/src/syscall/task/job.rs
@@ -28,7 +28,7 @@ pub fn sys_getpgid(pid: Pid) -> AxResult<isize> {
 pub fn sys_setpgid(pid: Pid, pgid: Pid) -> AxResult<isize> {
     let proc = &get_process_data(pid)?.proc;
 
-    if pgid == 0 {
+    if pgid == 0 || pgid == proc.pid() {
         proc.create_group();
     } else if !proc.move_to_group(&get_process_group(pgid)?) {
         return Err(AxError::OperationNotPermitted);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributing guide: https://github.com/Starry-OS/StarryOS?tab=contributing-ov-file#contributing-guide

Before submitting the PR, please ensure that your PR satisfies these requirements:
- Code formatted with `cargo fmt`
- Passed `cargo clippy` checks
- PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- Updated relevant documentation (if applicable)
-->

<!--
Related issues (if applicable)

If your PR solves one or more specific issues, you may link them here.
-->

## Description

<!--
A clear and concise description of what this PR does and what changes it makes.

Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

This PR adds support for Netlink Socket. It is based on https://github.com/Starry-OS/arceos/pull/25 and should be processed after that PR is merged.

Other Features and Fixes:

1. Fix setpgid behavior: Updated setpgid to call create_group if pgid == pid. This fixes the behavior to conform to the standard: [https://man7.org/linux/man-pages/man2/setpgid.2.html](https://www.google.com/url?sa=E&q=https%3A%2F%2Fman7.org%2Flinux%2Fman-pages%2Fman2%2Fsetpgid.2.html).
2.  Add ioctl support: Added support for FIOCLEX and FIONCLEX commands, which are used to control the FD_CLOEXEC flag (set_cloexec).