### PR TITLE
fix: `sys_rt_sigsuspend` should return `EINTR`

### DIFF
--- a/api/src/syscall/signal.rs
+++ b/api/src/syscall/signal.rs
@@ -293,8 +293,7 @@ pub fn sys_rt_sigsuspend(
         Poll::Pending
     }));
 
-    // Return -EINTR to match Linux behavior
-    // sigsuspend always returns -1 with errno=EINTR after handling a signal
+    // sigsuspend always returns -EINTR
     Err(AxError::Interrupted)
 }
 


### PR DESCRIPTION
# **Description**

This PR fixes a long-standing issue where UnixBench’s `shell1`/`shell8`/`shell16` test suites would freeze indefinitely on StarryOS. The hang was caused by incorrect return semantics in `sys_rt_sigsuspend`, which broke BusyBox `/bin/sh`’s internal `wait` logic.

POSIX requires `sigsuspend()` to always return `-1` with `errno = EINTR` after being interrupted by a signal. However, StarryOS previously returned `0`, causing `/bin/sh` to incorrectly assume that `sigsuspend()` returned normally instead of being interrupted by `SIGCHLD`. This prevented the shell from collecting child statuses in time, ultimately causing the entire UnixBench shell test to stall.

This PR brings StarryOS’s `sigsuspend` behavior in line with Linux/POSIX semantics and fixes related process-table handling issues.

An analysis is detailed in https://haozewu.notion.site/StarryOS-sys_rt_sigsuspend-2c02127bdf2e80ee8d1acaadc63def99?source=copy_link, writen by @TomGoh.

---

# **Implementation**

### **Fix `sys_rt_sigsuspend` return semantics**

* Pre-set `uctx.retval = -EINTR` before signal handling so that the value is preserved in the signal frame.
* After the poll loop completes due to a signal, return `Err(AxError::Interrupted)` rather than `Ok(0)`.
* This matches Linux:

  > *“sigsuspend always returns −1 with errno = EINTR after a signal is caught.”*

This ensures that `/bin/sh` correctly recognizes that the blocking call was interrupted by `SIGCHLD` and properly continues its `wait` state machine.

---

# **Related Issue**

[[bug] UnixBench shell tests hanging #36](https://github.com/kylin-x-kernel/StarryOS/issues/36)

