### PR TITLE
feat: RK3588 opi5plus platform support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "arm-gic"
+version = "0.6.0"
+source = "git+https://github.com/google/arm-gic.git?tag=0.6.0#56875f22e35b53d48e3fb67f02d01a37591303ec"
+dependencies = [
+ "bitflags 2.10.0",
+ "safe-mmio",
+ "thiserror",
+ "zerocopy 0.8.31",
+]
+
+[[package]]
 name = "arm-gic-driver"
 version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -279,6 +290,7 @@ dependencies = [
  "axhal",
  "cfg-if",
  "crate_interface",
+ "gpt_disk_io",
  "log",
  "smallvec",
 ]
@@ -446,7 +458,7 @@ dependencies = [
  "axconfig",
  "axcpu",
  "axlog",
- "axplat",
+ "axplat 0.3.0 (git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03)",
  "axplat-aarch64-qemu-virt",
  "axplat-loongarch64-qemu-virt",
  "axplat-riscv64-qemu-virt",
@@ -546,7 +558,22 @@ name = "axplat"
 version = "0.3.0"
 source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
- "axplat-macros",
+ "axplat-macros 0.1.0 (git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03)",
+ "bitflags 2.10.0",
+ "const-str",
+ "crate_interface",
+ "handler_table",
+ "kspin",
+ "memory_addr",
+ "percpu",
+]
+
+[[package]]
+name = "axplat"
+version = "0.3.0"
+source = "git+https://github.com/elliott10/axplat_crates.git?rev=0ea84c51#0ea84c512b819cfb05e3c1a9eb8fab22b3985469"
+dependencies = [
+ "axplat-macros 0.1.0 (git+https://github.com/elliott10/axplat_crates.git?rev=0ea84c51)",
  "bitflags 2.10.0",
  "const-str",
  "crate_interface",
@@ -566,7 +593,27 @@ dependencies = [
  "arm_pl011",
  "arm_pl031",
  "axcpu",
- "axplat",
+ "axplat 0.3.0 (git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03)",
+ "int_ratio",
+ "kspin",
+ "lazyinit",
+ "log",
+ "page_table_entry",
+ "spin 0.10.0",
+]
+
+[[package]]
+name = "axplat-aarch64-peripherals"
+version = "0.3.0"
+source = "git+https://github.com/elliott10/axplat_crates.git?rev=0ea84c51#0ea84c512b819cfb05e3c1a9eb8fab22b3985469"
+dependencies = [
+ "aarch64-cpu",
+ "arm-gic",
+ "arm-gic-driver",
+ "arm_pl011",
+ "arm_pl031",
+ "axcpu",
+ "axplat 0.3.0 (git+https://github.com/elliott10/axplat_crates.git?rev=0ea84c51)",
  "int_ratio",
  "kspin",
  "lazyinit",
@@ -582,8 +629,8 @@ source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df071
 dependencies = [
  "axconfig-macros",
  "axcpu",
- "axplat",
- "axplat-aarch64-peripherals",
+ "axplat 0.3.0 (git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03)",
+ "axplat-aarch64-peripherals 0.3.0 (git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03)",
  "log",
  "page_table_entry",
 ]
@@ -591,12 +638,12 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-rk3588"
 version = "0.2.0"
-source = "git+https://github.com/elliott10/axplat-aarch64-rk3588.git?rev=e4799437#e47994378da5324c0dcd27fc4212c919b60c9606"
+source = "git+https://github.com/Starry-OS/axplat-aarch64-rk3588.git?rev=c8f2bbf0#c8f2bbf0a6a4adb617f6b9ba5d3266048887b6d2"
 dependencies = [
  "axconfig-macros",
  "axcpu",
- "axplat",
- "axplat-aarch64-peripherals",
+ "axplat 0.3.0 (git+https://github.com/elliott10/axplat_crates.git?rev=0ea84c51)",
+ "axplat-aarch64-peripherals 0.3.0 (git+https://github.com/elliott10/axplat_crates.git?rev=0ea84c51)",
  "dw_apb_uart",
  "kspin",
  "log",
@@ -610,7 +657,7 @@ source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df071
 dependencies = [
  "axconfig-macros",
  "axcpu",
- "axplat",
+ "axplat 0.3.0 (git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03)",
  "chrono",
  "kspin",
  "lazyinit",
@@ -631,13 +678,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "axplat-macros"
+version = "0.1.0"
+source = "git+https://github.com/elliott10/axplat_crates.git?rev=0ea84c51#0ea84c512b819cfb05e3c1a9eb8fab22b3985469"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "axplat-riscv64-qemu-virt"
 version = "0.3.0"
 source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axconfig-macros",
  "axcpu",
- "axplat",
+ "axplat 0.3.0 (git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03)",
  "kspin",
  "lazyinit",
  "log",
@@ -655,7 +712,7 @@ source = "git+https://github.com/Starry-OS/axplat-riscv64-visionfive2.git?tag=de
 dependencies = [
  "axconfig-macros",
  "axcpu",
- "axplat",
+ "axplat 0.3.0 (git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03)",
  "kspin",
  "lazyinit",
  "log",
@@ -673,7 +730,7 @@ source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df071
 dependencies = [
  "axconfig-macros",
  "axcpu",
- "axplat",
+ "axplat 0.3.0 (git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03)",
  "bitflags 2.10.0",
  "heapless 0.9.2",
  "int_ratio",
@@ -716,7 +773,7 @@ dependencies = [
  "axlog",
  "axmm",
  "axnet",
- "axplat",
+ "axplat 0.3.0 (git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03)",
  "axtask",
  "chrono",
  "crate_interface",
@@ -1022,6 +1079,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1289,6 +1361,28 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gpt_disk_io"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb194b955ba40423510e4342a077df49c70a599cf692cd0e30a86a32d8a9c7b1"
+dependencies = [
+ "bytemuck",
+ "gpt_disk_types",
+]
+
+[[package]]
+name = "gpt_disk_types"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3972298dc4cef533492b66bdd75747133618917f44885a11dc8abd24c4e3f1f0"
+dependencies = [
+ "bytemuck",
+ "crc",
+ "ucs2",
+ "uguid",
+]
 
 [[package]]
 name = "handler_table"
@@ -2015,6 +2109,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "safe-mmio"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e278214ff688cacb43a8e71611d1fd1b0788a8b55a054dbce9a9b70b9a6a6f2"
+dependencies = [
+ "zerocopy 0.8.31",
+]
+
+[[package]]
 name = "sbi-rt"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,6 +2541,24 @@ dependencies = [
  "bitflags 2.10.0",
  "rustversion",
  "x86",
+]
+
+[[package]]
+name = "ucs2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79298e11f316400c57ec268f3c2c29ac3c4d4777687955cd3d4f3a35ce7eba"
+dependencies = [
+ "bit_field",
+]
+
+[[package]]
+name = "uguid"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8352f8c05e47892e7eaf13b34abd76a7f4aeaf817b716e88789381927f199c"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,7 +20,6 @@ dependencies = [
  "cpp_demangle",
  "gimli",
  "rustc-demangle",
- "rustc-std-workspace-alloc",
 ]
 
 [[package]]
@@ -189,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "axbacktrace"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac82d77c48f98335e4f9b546ef69356d429ee7e9933560bb55696f498a1a26dc"
+checksum = "bf9566516f5d799b2f791a6ec5af57eec87d17624346f7c876fa006b922c99e6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -233,7 +232,7 @@ dependencies = [
 [[package]]
 name = "axcpu"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axcpu.git?tag=dev-v03#1dc46de5d5a0b6befba9fa25a560386e5d9e19c6"
+source = "git+https://github.com/arceos-org/axcpu.git?tag=dev-v03#72ef3859952b7340bae261c9a50c32705e602017"
 dependencies = [
  "aarch64-cpu",
  "axbacktrace",
@@ -287,12 +286,12 @@ dependencies = [
 [[package]]
 name = "axdriver_base"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#498df4ecde85b8acc2553d93102ad32d76339110"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#16f1ae864e1317f67d4e22a645fcb7399ae86596"
 
 [[package]]
 name = "axdriver_block"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#498df4ecde85b8acc2553d93102ad32d76339110"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#16f1ae864e1317f67d4e22a645fcb7399ae86596"
 dependencies = [
  "axdriver_base",
  "log",
@@ -302,7 +301,7 @@ dependencies = [
 [[package]]
 name = "axdriver_display"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#498df4ecde85b8acc2553d93102ad32d76339110"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#16f1ae864e1317f67d4e22a645fcb7399ae86596"
 dependencies = [
  "axdriver_base",
 ]
@@ -310,7 +309,7 @@ dependencies = [
 [[package]]
 name = "axdriver_input"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#498df4ecde85b8acc2553d93102ad32d76339110"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#16f1ae864e1317f67d4e22a645fcb7399ae86596"
 dependencies = [
  "axdriver_base",
  "strum",
@@ -319,7 +318,7 @@ dependencies = [
 [[package]]
 name = "axdriver_net"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#498df4ecde85b8acc2553d93102ad32d76339110"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#16f1ae864e1317f67d4e22a645fcb7399ae86596"
 dependencies = [
  "axdriver_base",
  "log",
@@ -329,7 +328,7 @@ dependencies = [
 [[package]]
 name = "axdriver_pci"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#498df4ecde85b8acc2553d93102ad32d76339110"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#16f1ae864e1317f67d4e22a645fcb7399ae86596"
 dependencies = [
  "virtio-drivers",
 ]
@@ -337,7 +336,7 @@ dependencies = [
 [[package]]
 name = "axdriver_virtio"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#498df4ecde85b8acc2553d93102ad32d76339110"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#16f1ae864e1317f67d4e22a645fcb7399ae86596"
 dependencies = [
  "axdriver_base",
  "axdriver_block",
@@ -352,7 +351,7 @@ dependencies = [
 [[package]]
 name = "axdriver_vsock"
 version = "0.1.2"
-source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#498df4ecde85b8acc2553d93102ad32d76339110"
+source = "git+https://github.com/arceos-org/axdriver_crates.git?tag=dev-v01#16f1ae864e1317f67d4e22a645fcb7399ae86596"
 dependencies = [
  "axdriver_base",
  "log",
@@ -545,7 +544,7 @@ dependencies = [
 [[package]]
 name = "axplat"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#72b148262f4f58a3a6c64c23d0f377e6469b662a"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axplat-macros",
  "bitflags 2.10.0",
@@ -560,7 +559,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-peripherals"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#72b148262f4f58a3a6c64c23d0f377e6469b662a"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "aarch64-cpu",
  "arm-gic-driver",
@@ -579,7 +578,7 @@ dependencies = [
 [[package]]
 name = "axplat-aarch64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#72b148262f4f58a3a6c64c23d0f377e6469b662a"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -590,9 +589,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "axplat-aarch64-rk3588"
+version = "0.2.0"
+source = "git+https://github.com/elliott10/axplat-aarch64-rk3588.git?rev=e4799437#e47994378da5324c0dcd27fc4212c919b60c9606"
+dependencies = [
+ "axconfig-macros",
+ "axcpu",
+ "axplat",
+ "axplat-aarch64-peripherals",
+ "dw_apb_uart",
+ "kspin",
+ "log",
+ "page_table_entry",
+]
+
+[[package]]
 name = "axplat-loongarch64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#72b148262f4f58a3a6c64c23d0f377e6469b662a"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -609,7 +623,7 @@ dependencies = [
 [[package]]
 name = "axplat-macros"
 version = "0.1.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#72b148262f4f58a3a6c64c23d0f377e6469b662a"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -619,7 +633,7 @@ dependencies = [
 [[package]]
 name = "axplat-riscv64-qemu-virt"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#72b148262f4f58a3a6c64c23d0f377e6469b662a"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -629,7 +643,7 @@ dependencies = [
  "log",
  "riscv",
  "riscv_goldfish",
- "riscv_plic",
+ "riscv_plic 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sbi-rt",
  "uart_16550",
 ]
@@ -647,7 +661,7 @@ dependencies = [
  "log",
  "riscv",
  "riscv_goldfish",
- "riscv_plic",
+ "riscv_plic 0.2.0 (git+https://github.com/arceos-org/riscv_plic.git?tag=dev-v02)",
  "sbi-rt",
  "uart_16550",
 ]
@@ -655,7 +669,7 @@ dependencies = [
 [[package]]
 name = "axplat-x86-pc"
 version = "0.3.0"
-source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#72b148262f4f58a3a6c64c23d0f377e6469b662a"
+source = "git+https://github.com/arceos-org/axplat_crates.git?tag=dev-v03#0df0713b1c20eafaeebdc6b0e194b2985e857949"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -971,9 +985,9 @@ checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
 
 [[package]]
 name = "convert_case"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1097,24 +1111,33 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+checksum = "10b768e943bed7bf2cab53df09f4bc34bfd217cdb57d971e769874c9a6710618"
 dependencies = [
  "derive_more-impl",
 ]
 
 [[package]]
 name = "derive_more-impl"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+checksum = "6d286bfdaf75e988b4a78e013ecd79c581e06399ab53fbacd2d916c2f904f30b"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn 2.0.111",
  "unicode-xid",
+]
+
+[[package]]
+name = "dw_apb_uart"
+version = "0.2.0"
+source = "git+https://github.com/elliott10/dw_apb_uart.git?rev=9de1bf0f#9de1bf0fb36a17ba2cc29cbed47131ed1b8de12f"
+dependencies = [
+ "tock-registers 0.8.1",
 ]
 
 [[package]]
@@ -1410,14 +1433,14 @@ source = "git+https://github.com/Starry-OS/kernel_elf_parser.git?rev=fdcce74#fdc
 dependencies = [
  "xmas-elf",
  "zero",
- "zerocopy 0.8.30",
+ "zerocopy 0.8.31",
 ]
 
 [[package]]
 name = "kernel_guard"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307e6be468f3d6b6d895e191f63c11602e4e76575ecca68325d8c8dbebe2870e"
+checksum = "d10c55bedf6789bc3748e0d8756ee639df1ae25144fd3525ed311044bd9a739f"
 dependencies = [
  "cfg-if",
  "crate_interface",
@@ -1450,9 +1473,9 @@ checksum = "17f03abfebdaaf0fad16790237a0348baf84886d3ade460db13bae59e614a180"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libloading"
@@ -1507,9 +1530,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.28"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "loongArch64"
@@ -1938,6 +1961,15 @@ checksum = "07aac72f95e774476db82916d79f2d303191310393830573c1ab5c821b21660a"
 [[package]]
 name = "riscv_plic"
 version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e701d1c6ea06c35a19cb80d213fab87d264798f9bac0aed2730c0e86d297394a"
+dependencies = [
+ "tock-registers 0.10.1",
+]
+
+[[package]]
+name = "riscv_plic"
+version = "0.2.0"
 source = "git+https://github.com/arceos-org/riscv_plic.git?tag=dev-v02#e2643d2cd44b862b9d505d7caf8938ddad33e205"
 dependencies = [
  "tock-registers 0.10.1",
@@ -1968,10 +2000,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
-name = "rustc-std-workspace-alloc"
-version = "1.0.1"
+name = "rustc_version"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d441c3b2ebf55cebf796bfdc265d67fa09db17b7bb6bd4be75c509e1e8fec3"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustversion"
@@ -2009,6 +2044,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "shlex"
@@ -2094,6 +2135,7 @@ dependencies = [
  "axfs-ng",
  "axhal",
  "axlog",
+ "axplat-aarch64-rk3588",
  "axplat-riscv64-visionfive2",
  "axruntime",
  "axsync",
@@ -2158,7 +2200,7 @@ dependencies = [
  "starry-vm",
  "syscalls",
  "x86",
- "zerocopy 0.8.30",
+ "zerocopy 0.8.31",
 ]
 
 [[package]]
@@ -2504,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
 ]
@@ -2591,11 +2633,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea879c944afe8a2b25fef16bb4ba234f47c694565e97383b36f3a878219065c"
+checksum = "fd74ec98b9250adb3ca554bdde269adf631549f51d8a8f8f0a10b50f1cb298c3"
 dependencies = [
- "zerocopy-derive 0.8.30",
+ "zerocopy-derive 0.8.31",
 ]
 
 [[package]]
@@ -2611,9 +2653,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.30"
+version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf955aa904d6040f70dc8e9384444cb1030aed272ba3cb09bbc4ab9e7c1f34f5"
+checksum = "d8a8d209fdf45cf5138cbb5a506f6b52522a25afccc534d1475dad8e31105c6a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,9 +113,11 @@ qemu = [
     "axfeat/fs-times",
     "starry-api/dev-log",
 ]
-smp = ["axfeat/smp", "axplat-riscv64-visionfive2?/smp"]
+smp = ["axfeat/smp", "axplat-riscv64-visionfive2?/smp", "axplat-aarch64-rk3588?/smp"]
 
 vf2 = ["dep:axplat-riscv64-visionfive2", "axfeat/driver-sdmmc"]
+
+rk3588 = ["dep:axplat-aarch64-rk3588", "axfeat/driver-sdmmc"]
 
 [dependencies]
 axdriver.workspace = true
@@ -136,11 +138,19 @@ starry-signal.workspace = true
 starry-core.workspace = true
 starry-api.workspace = true
 
+
 [dependencies.axplat-riscv64-visionfive2]
 version = "0.3"
 git = "https://github.com/Starry-OS/axplat-riscv64-visionfive2.git"
 tag = "dev-v03"
 features = ["fp-simd", "irq", "rtc"]
+optional = true
+
+[dependencies.axplat-aarch64-rk3588]
+version = "0.2"
+git = "https://github.com/elliott10/axplat-aarch64-rk3588.git"
+rev = "e4799437"
+features = ["fp-simd", "irq", "rtc", "smp"]
 optional = true
 
 [package.metadata.vendor-filter]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,9 +148,9 @@ optional = true
 
 [dependencies.axplat-aarch64-rk3588]
 version = "0.2"
-git = "https://github.com/elliott10/axplat-aarch64-rk3588.git"
-rev = "e4799437"
-features = ["fp-simd", "irq", "rtc", "smp"]
+git = "https://github.com/Starry-OS/axplat-aarch64-rk3588.git"
+rev = "c8f2bbf0"
+features = ["fp-simd", "irq", "rtc"]
 optional = true
 
 [package.metadata.vendor-filter]

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,6 @@ vf2:
 	$(MAKE) ARCH=riscv64 APP_FEATURES=vf2 MYPLAT=axplat-riscv64-visionfive2 BUS=mmio build
 
 rk3588:
-	$(MAKE) ARCH=aarch64 APP_FEATURES=rk3588 MYPLAT=axplat-aarch64-rk3588 BUS=mmio SMP=8 UIMAGE=y LOG=info build
+	$(MAKE) ARCH=aarch64 APP_FEATURES=rk3588 MYPLAT=axplat-aarch64-rk3588 BUS=mmio SMP=1 UIMAGE=y LOG=info build
 
 .PHONY: build run justrun debug disasm clean

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,7 @@ la:
 vf2:
 	$(MAKE) ARCH=riscv64 APP_FEATURES=vf2 MYPLAT=axplat-riscv64-visionfive2 BUS=mmio build
 
+rk3588:
+	$(MAKE) ARCH=aarch64 APP_FEATURES=rk3588 MYPLAT=axplat-aarch64-rk3588 BUS=mmio SMP=8 UIMAGE=y LOG=info build
+
 .PHONY: build run justrun debug disasm clean

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,3 +41,6 @@ fn main() {
 
 #[cfg(feature = "vf2")]
 extern crate axplat_riscv64_visionfive2;
+
+#[cfg(feature = "rk3588")]
+extern crate axplat_aarch64_rk3588;


### PR DESCRIPTION

#### Support  RK3588 opi5plus board
* Added RK3588 opi5plus board platform crate
* How to: `make rk3588`
* Build and generate a U-Boot bootable image
`make ARCH=aarch64 APP_FEATURES=rk3588 MYPLAT=axplat-aarch64-rk3588 BUS=mmio SMP=8 UIMAGE=y LOG=info build`
Form an independent crate to support hardware platform, please see [axplat-aarch64-rk3588](https://github.com/elliott10/axplat-aarch64-rk3588.git)

* Updated serial device UART driver and dynamic adjustment of baud rate is supported
Please see: [dw-apb-uart](https://github.com/elliott10/dw_apb_uart.git)