### PR TITLE
Unixbench bug fix

### DIFF
--- a/api/src/syscall/mm/brk.rs
+++ b/api/src/syscall/mm/brk.rs
@@ -1,16 +1,51 @@
 use axerrno::AxResult;
+use axhal::paging::{MappingFlags, PageSize};
+use axmm::backend::Backend;
 use axtask::current;
+use memory_addr::{align_up_4k, VirtAddr};
 use starry_core::task::AsThread;
 
 pub fn sys_brk(addr: usize) -> AxResult<isize> {
     let curr = current();
     let proc_data = &curr.as_thread().proc_data;
-    let mut return_val: isize = proc_data.get_heap_top() as isize;
     let heap_bottom = proc_data.get_heap_bottom() as usize;
-    if addr != 0 && addr >= heap_bottom && addr <= heap_bottom + starry_core::config::USER_HEAP_SIZE
-    {
-        proc_data.set_heap_top(addr);
-        return_val = addr as isize;
+    let current_top = proc_data.get_heap_top() as usize;
+    let heap_limit = heap_bottom + starry_core::config::USER_HEAP_SIZE_MAX;
+    
+    if addr == 0 {
+        return Ok(current_top as isize);
     }
-    Ok(return_val)
+    
+    if addr < heap_bottom || addr > heap_limit {
+        return Ok(current_top as isize);
+    }
+    
+    let new_top_aligned = align_up_4k(addr);
+    let current_top_aligned = align_up_4k(current_top);
+    // Initial heap region end address (already mapped during ELF loading)
+    let initial_heap_end = heap_bottom + starry_core::config::USER_HEAP_SIZE;
+    
+    // Only map new pages when expanding beyond already mapped region
+    // Expansion start should be the greater of initial_heap_end and current_top_aligned
+    if new_top_aligned > current_top_aligned {
+        let expand_start = VirtAddr::from(initial_heap_end.max(current_top_aligned));
+        let expand_size = new_top_aligned.saturating_sub(expand_start.as_usize());
+        
+        if expand_size > 0 {
+            let mut aspace = proc_data.aspace.lock();
+            if aspace.map(
+                expand_start,
+                expand_size,
+                MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
+                true,
+                Backend::new_alloc(expand_start, PageSize::Size4K),
+            ).is_err() {
+                return Ok(current_top as isize);
+            }
+            drop(aspace);
+        }
+    }
+    
+    proc_data.set_heap_top(addr);
+    Ok(addr as isize)
 }

--- a/api/src/syscall/mm/mmap.rs
+++ b/api/src/syscall/mm/mmap.rs
@@ -335,3 +335,9 @@ pub fn sys_mlock(addr: usize, length: usize) -> AxResult<isize> {
 pub fn sys_mlock2(_addr: usize, _length: usize, _flags: u32) -> AxResult<isize> {
     Ok(0)
 }
+
+/// Check whether pages are resident in memory.
+/// Returns ENOSYS (Unsupported) to let programs use fallback logic.
+pub fn sys_mincore(_addr: usize, _length: usize, _vec: usize) -> AxResult<isize> {
+    Err(AxError::Unsupported)
+}

--- a/api/src/syscall/mod.rs
+++ b/api/src/syscall/mod.rs
@@ -357,6 +357,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::msync => sys_msync(uctx.arg0(), uctx.arg1() as _, uctx.arg2() as _),
         Sysno::mlock => sys_mlock(uctx.arg0(), uctx.arg1() as _),
         Sysno::mlock2 => sys_mlock2(uctx.arg0(), uctx.arg1() as _, uctx.arg2() as _),
+        Sysno::mincore => sys_mincore(uctx.arg0(), uctx.arg1() as _, uctx.arg2()),
 
         // task info
         Sysno::getpid => sys_getpid(),

--- a/api/src/syscall/task/ctl.rs
+++ b/api/src/syscall/task/ctl.rs
@@ -99,12 +99,26 @@ pub fn sys_prctl(
         }
         PR_SET_SECCOMP => {}
         PR_MCE_KILL => {}
-        PR_SET_MM_START_CODE
-        | PR_SET_MM_END_CODE
-        | PR_SET_MM_START_DATA
-        | PR_SET_MM_END_DATA
-        | PR_SET_MM_START_BRK
-        | PR_SET_MM_START_STACK => {}
+        PR_SET_MM => match arg2 as u32 {
+            PR_SET_MM_START_CODE
+            | PR_SET_MM_END_CODE
+            | PR_SET_MM_START_DATA
+            | PR_SET_MM_END_DATA
+            | PR_SET_MM_START_BRK
+            | PR_SET_MM_BRK
+            | PR_SET_MM_START_STACK
+            | PR_SET_MM_ARG_START
+            | PR_SET_MM_ARG_END
+            | PR_SET_MM_ENV_START
+            | PR_SET_MM_ENV_END
+            | PR_SET_MM_AUXV
+            | PR_SET_MM_EXE_FILE
+            | PR_SET_MM_MAP => {}
+            _ => {
+                warn!("sys_prctl: unsupported PR_SET_MM sub-option {:#x}", arg2);
+                return Err(AxError::InvalidInput);
+            }
+        },
         _ => {
             warn!("sys_prctl: unsupported option {option}");
             return Err(AxError::InvalidInput);

--- a/api/src/syscall/task/execve.rs
+++ b/api/src/syscall/task/execve.rs
@@ -5,7 +5,7 @@ use axerrno::{AxError, AxResult};
 use axfs::FS_CONTEXT;
 use axhal::uspace::UserContext;
 use axtask::current;
-use starry_core::{mm::load_user_app, task::AsThread};
+use starry_core::{config::USER_HEAP_BASE, mm::load_user_app, task::AsThread};
 use starry_vm::vm_load_until_nul;
 
 use crate::{file::FD_TABLE, mm::vm_load_string};
@@ -60,7 +60,14 @@ pub fn sys_execve(
     *proc_data.exe_path.write() = loc.absolute_path()?.to_string();
     *proc_data.cmdline.write() = Arc::new(args);
 
+    // Reset heap pointers after execve; brk logic will handle initial heap region
+    proc_data.set_heap_bottom(USER_HEAP_BASE);
+    proc_data.set_heap_top(USER_HEAP_BASE);
+
     *proc_data.signal.actions.lock() = Default::default();
+
+    // Clear set_child_tid after exec since the original address is no longer valid
+    curr.as_thread().set_clear_child_tid(0);
 
     // Close CLOEXEC file descriptors
     let mut fd_table = FD_TABLE.write();

--- a/api/src/syscall/task/wait.rs
+++ b/api/src/syscall/task/wait.rs
@@ -90,13 +90,15 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
 
     let check_children = || {
         if let Some(child) = children.iter().find(|child| child.is_zombie()) {
+            let child_pid = child.pid();
+            let child_exit_code = child.exit_code();
             if !options.contains(WaitOptions::WNOWAIT) {
                 child.free();
             }
             if let Some(exit_code) = exit_code.nullable() {
-                exit_code.vm_write(child.exit_code())?;
+                exit_code.vm_write(child_exit_code)?;
             }
-            Ok(Some(child.pid() as _))
+            Ok(Some(child_pid as _))
         } else if options.contains(WaitOptions::WNOHANG) {
             Ok(Some(0))
         } else {

--- a/core/src/config/aarch64.rs
+++ b/core/src/config/aarch64.rs
@@ -15,9 +15,11 @@ pub const USER_STACK_SIZE: usize = 0x8_0000;
 pub const USER_HEAP_BASE: usize = 0x4000_0000;
 /// The size of the user heap.
 pub const USER_HEAP_SIZE: usize = 0x1_0000;
+/// The maximum size of the user heap (for brk expansion).
+pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;

--- a/core/src/config/loongarch64.rs
+++ b/core/src/config/loongarch64.rs
@@ -14,10 +14,12 @@ pub const USER_STACK_SIZE: usize = 0x8_0000;
 /// The lowest address of the user heap.
 pub const USER_HEAP_BASE: usize = 0x4000_0000;
 /// The size of the user heap.
-pub const USER_HEAP_SIZE: usize = 0x1_0000;
+pub const USER_HEAP_SIZE: usize = 0x1_0000;  // 64KB
+/// The maximum size of the user heap (for brk expansion).
+pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;  // 512MB
 
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;

--- a/core/src/config/riscv64.rs
+++ b/core/src/config/riscv64.rs
@@ -15,9 +15,11 @@ pub const USER_STACK_SIZE: usize = 0x8_0000;
 pub const USER_HEAP_BASE: usize = 0x4000_0000;
 /// The size of the user heap.
 pub const USER_HEAP_SIZE: usize = 0x1_0000;
+/// The maximum size of the user heap (for brk expansion).
+pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;

--- a/core/src/config/x86_64.rs
+++ b/core/src/config/x86_64.rs
@@ -15,9 +15,11 @@ pub const USER_STACK_SIZE: usize = 0x8_0000;
 pub const USER_HEAP_BASE: usize = 0x4000_0000;
 /// The size of the user heap.
 pub const USER_HEAP_SIZE: usize = 0x1_0000;
+/// The maximum size of the user heap (for brk expansion).
+pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributing guide: https://github.com/Starry-OS/StarryOS?tab=contributing-ov-file#contributing-guide

Before submitting the PR, please ensure that your PR satisfies these requirements:
- Code formatted with `cargo fmt`
- Passed `cargo clippy` checks
- PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- Updated relevant documentation (if applicable)
-->

<!--
Related issues (if applicable)

If your PR solves one or more specific issues, you may link them here.
-->
Unixbench bug fix
## Description

<!--
A clear and concise description of what this PR does and what changes it makes.

Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->
After rebasing onto the main branch, I re-ran the UnixBench shell tests. During the test runs, aborting errors like the following occurred frequently:

Run: "Shell Scripts (1 concurrent)": command returned status 139; aborting

After multiple rounds of debugging and analysis, the issue was suspected to be insufficient heap memory. Therefore, while keeping the original 64 KB eagerly allocated heap, I enabled dynamic heap expansion via the brk system call and performed the necessary adaptations and bug fixes.

## Implementation

<!--
Describe how you implemented it. What design decisions did you make and why?

If there are any trade-offs or limitations, please describe them here.
-->

### 1. COW (Copy-on-Write) Race Condition in Multi-core Environment

**File**: `arceos/modules/axmm/src/backend/cow.rs`

**Bug Description**:
In a multi-core (SMP) environment, when two processes sharing the same COW page simultaneously trigger a write fault, a race condition occurs:

**Fix**:
Keep the FRAME_TABLE lock held **during the entire page copy operation**:

```rust
fn handle_cow_fault(...) -> AxResult {
    let mut table = FRAME_TABLE.lock();
    
    let count = table.get_mut(&paddr).ok_or(AxError::BadAddress)?;
    
    if *count == 1 {
        // Only one reference, just restore write permission
        drop(table);
        pt.protect(vaddr, flags)?;
    } else {
        // Multiple references - allocate, copy, then release lock
        let new_frame = alloc_frame(false, self.size)?;
        *count -= 1;
        
        // Copy while holding lock - prevents another process from
        // seeing count=1 and modifying the source page
        unsafe {
            core::ptr::copy_nonoverlapping(...);
        }
        
        drop(table);  // Release lock after copying
        inc_frame_ref(new_frame);
        pt.remap(vaddr, new_frame, flags)?;
    }
    Ok(())
}
```

**Key insight**: The page copy must complete before any other process can see count=1 and start writing to the original page.

---

### 2. brk Syscall Double-Mapping Issue

**File**: `api/src/syscall/mm/brk.rs`

**Bug Description**:
The original `brk` implementation did not properly track the initial heap region that was already mapped during ELF loading. When a process called `brk` to expand the heap, it would attempt to map pages that were already mapped, causing `AlreadyExists` errors.

**Fix**:
- Track `initial_heap_end` (USER_HEAP_BASE + USER_HEAP_SIZE) as the end of the pre-mapped region
- Use `initial_heap_end.max(current_top_aligned)` as the expansion start point
- Only map new pages when expanding beyond the already mapped region
- Use `saturating_sub` to avoid negative sizes

---

### 3. Fork Not Inheriting Heap Pointers

**File**: `api/src/syscall/task/clone.rs`

**Bug Description**:
After `fork`, the child process's `heap_bottom` and `heap_top` were initialized to `USER_HEAP_BASE` instead of inheriting the parent's heap state. This caused the child's `brk` calls to behave incorrectly.

**Fix**:
Added heap pointer inheritance in the fork path:
```rust
proc_data.set_heap_bottom(old_proc_data.get_heap_bottom());
proc_data.set_heap_top(old_proc_data.get_heap_top());
```

---

### 4. set_child_tid / clear_child_tid NULL Pointer Issues

**Files**: 
- `api/src/syscall/task/clone.rs`
- `api/src/task.rs`

**Bug Description**:
When `CLONE_CHILD_SETTID` or `CLONE_CHILD_CLEARTID` flags were set but the `child_tid` pointer was NULL (0), the kernel would attempt to dereference a null pointer or access invalid memory.

**Fix**:
- Check both the flag and whether the address is non-NULL before processing
- Pass the address as `usize` instead of a pointer reference
- Write to the address using the address space's `write` method in the child task's context
- For `clear_child_tid`, validate the address is in a valid area before attempting to write

---

### 5. VmIo Lazy Allocation Failure

**Files**:
- `core/src/mm.rs`
- `api/src/io.rs`
- `api/src/mm.rs`

**Bug Description**:
When the kernel tried to read/write user memory that was lazily allocated but not yet faulted in, the operation would fail with `AccessDenied` instead of triggering page fault handling.

**Fix**:
Added retry logic with page population:
1. First attempt the read/write
2. If failed, calculate the faulting address from the failure offset
3. Call `populate_area` to ensure the pages are allocated
4. Retry the read/write operation

---

### 6. execve Not Clearing clear_child_tid

**File**: `api/src/syscall/task/execve.rs`

**Bug Description**:
After `execve`, the `clear_child_tid` address from the old address space remained set. When the process eventually exited, it would try to write to an invalid address.

**Fix**:
Clear `clear_child_tid` after `execve`:
```rust
curr.as_thread().set_clear_child_tid(0);
```

---

### 7. PR_SET_MM Handling in prctl

**File**: `api/src/syscall/task/ctl.rs`

**Bug Description**:
The `prctl` syscall was incorrectly matching `PR_SET_MM_*` constants at the top level instead of as sub-options of `PR_SET_MM`.

**Fix**:
Restructured the match to properly handle `PR_SET_MM` with its sub-options:
```rust
PR_SET_MM => match arg2 as u32 {
    PR_SET_MM_START_CODE | PR_SET_MM_END_CODE | ... => {}
    _ => return Err(AxError::InvalidInput),
}
```

---

### 8. Added USER_HEAP_SIZE_MAX Configuration

**Files**:
- `core/src/config/aarch64.rs`
- `core/src/config/loongarch64.rs`
- `core/src/config/riscv64.rs`
- `core/src/config/x86_64.rs`

**Description**:
Added `USER_HEAP_SIZE_MAX` (512MB) constant to limit maximum heap expansion via `brk`. This prevents unlimited heap growth.

---

### 9. Added mincore Syscall Stub

**File**: `api/src/syscall/mm/mmap.rs`

**Description**:
Added `sys_mincore` that returns `ENOSYS` (Unsupported). This is safer than returning incorrect data and lets programs use fallback logic.

---

### 10. ELF Segment Immediate Population

**File**: `core/src/mm.rs`

**Change**:
Changed ELF segment mapping to use `populate=true` to immediately allocate pages instead of relying on lazy allocation. This prevents potential issues with COW and page fault handling during early execution.


## Additional Context

<!--
Add any other context about the PR here.
-->
