### PR TITLE
fix(mm): fix brk syscall to properly map heap pages

### DIFF
--- a/api/src/syscall/mm/brk.rs
+++ b/api/src/syscall/mm/brk.rs
@@ -2,7 +2,7 @@ use axerrno::AxResult;
 use axhal::paging::{MappingFlags, PageSize};
 use axmm::backend::Backend;
 use axtask::current;
-use memory_addr::{align_up_4k, VirtAddr};
+use memory_addr::{VirtAddr, align_up_4k};
 use starry_core::task::AsThread;
 
 pub fn sys_brk(addr: usize) -> AxResult<isize> {
@@ -11,41 +11,44 @@ pub fn sys_brk(addr: usize) -> AxResult<isize> {
     let heap_bottom = proc_data.get_heap_bottom() as usize;
     let current_top = proc_data.get_heap_top() as usize;
     let heap_limit = heap_bottom + starry_core::config::USER_HEAP_SIZE_MAX;
-    
+
     if addr == 0 {
         return Ok(current_top as isize);
     }
-    
+
     if addr < heap_bottom || addr > heap_limit {
         return Ok(current_top as isize);
     }
-    
+
     let new_top_aligned = align_up_4k(addr);
     let current_top_aligned = align_up_4k(current_top);
     // Initial heap region end address (already mapped during ELF loading)
     let initial_heap_end = heap_bottom + starry_core::config::USER_HEAP_SIZE;
-    
+
     // Only map new pages when expanding beyond already mapped region
     // Expansion start should be the greater of initial_heap_end and current_top_aligned
     if new_top_aligned > current_top_aligned {
         let expand_start = VirtAddr::from(initial_heap_end.max(current_top_aligned));
         let expand_size = new_top_aligned.saturating_sub(expand_start.as_usize());
-        
+
         if expand_size > 0 {
             let mut aspace = proc_data.aspace.lock();
-            if aspace.map(
-                expand_start,
-                expand_size,
-                MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
-                true,
-                Backend::new_alloc(expand_start, PageSize::Size4K),
-            ).is_err() {
+            if aspace
+                .map(
+                    expand_start,
+                    expand_size,
+                    MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
+                    true,
+                    Backend::new_alloc(expand_start, PageSize::Size4K),
+                )
+                .is_err()
+            {
                 return Ok(current_top as isize);
             }
             drop(aspace);
         }
     }
-    
+
     proc_data.set_heap_top(addr);
     Ok(addr as isize)
 }

--- a/api/src/syscall/mm/brk.rs
+++ b/api/src/syscall/mm/brk.rs
@@ -1,16 +1,51 @@
 use axerrno::AxResult;
+use axhal::paging::{MappingFlags, PageSize};
+use axmm::backend::Backend;
 use axtask::current;
+use memory_addr::{align_up_4k, VirtAddr};
 use starry_core::task::AsThread;
 
 pub fn sys_brk(addr: usize) -> AxResult<isize> {
     let curr = current();
     let proc_data = &curr.as_thread().proc_data;
-    let mut return_val: isize = proc_data.get_heap_top() as isize;
     let heap_bottom = proc_data.get_heap_bottom() as usize;
-    if addr != 0 && addr >= heap_bottom && addr <= heap_bottom + starry_core::config::USER_HEAP_SIZE
-    {
-        proc_data.set_heap_top(addr);
-        return_val = addr as isize;
+    let current_top = proc_data.get_heap_top() as usize;
+    let heap_limit = heap_bottom + starry_core::config::USER_HEAP_SIZE_MAX;
+    
+    if addr == 0 {
+        return Ok(current_top as isize);
     }
-    Ok(return_val)
+    
+    if addr < heap_bottom || addr > heap_limit {
+        return Ok(current_top as isize);
+    }
+    
+    let new_top_aligned = align_up_4k(addr);
+    let current_top_aligned = align_up_4k(current_top);
+    // Initial heap region end address (already mapped during ELF loading)
+    let initial_heap_end = heap_bottom + starry_core::config::USER_HEAP_SIZE;
+    
+    // Only map new pages when expanding beyond already mapped region
+    // Expansion start should be the greater of initial_heap_end and current_top_aligned
+    if new_top_aligned > current_top_aligned {
+        let expand_start = VirtAddr::from(initial_heap_end.max(current_top_aligned));
+        let expand_size = new_top_aligned.saturating_sub(expand_start.as_usize());
+        
+        if expand_size > 0 {
+            let mut aspace = proc_data.aspace.lock();
+            if aspace.map(
+                expand_start,
+                expand_size,
+                MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
+                true,
+                Backend::new_alloc(expand_start, PageSize::Size4K),
+            ).is_err() {
+                return Ok(current_top as isize);
+            }
+            drop(aspace);
+        }
+    }
+    
+    proc_data.set_heap_top(addr);
+    Ok(addr as isize)
 }

--- a/api/src/syscall/mm/brk.rs
+++ b/api/src/syscall/mm/brk.rs
@@ -4,27 +4,27 @@ use axmm::backend::Backend;
 use axtask::current;
 use memory_addr::{VirtAddr, align_up_4k};
 use starry_core::task::AsThread;
+use starry_core::config::{USER_HEAP_BASE, USER_HEAP_SIZE, USER_HEAP_SIZE_MAX};
 
 pub fn sys_brk(addr: usize) -> AxResult<isize> {
     let curr = current();
     let proc_data = &curr.as_thread().proc_data;
-    let heap_bottom = proc_data.get_heap_bottom() as usize;
     let current_top = proc_data.get_heap_top() as usize;
-    let heap_limit = heap_bottom + starry_core::config::USER_HEAP_SIZE_MAX;
-
+    let heap_limit = USER_HEAP_BASE + USER_HEAP_SIZE_MAX;
+    
     if addr == 0 {
         return Ok(current_top as isize);
     }
-
-    if addr < heap_bottom || addr > heap_limit {
+    
+    if addr < USER_HEAP_BASE || addr > heap_limit {
         return Ok(current_top as isize);
     }
 
     let new_top_aligned = align_up_4k(addr);
     let current_top_aligned = align_up_4k(current_top);
     // Initial heap region end address (already mapped during ELF loading)
-    let initial_heap_end = heap_bottom + starry_core::config::USER_HEAP_SIZE;
-
+    let initial_heap_end = USER_HEAP_BASE + USER_HEAP_SIZE;
+    
     // Only map new pages when expanding beyond already mapped region
     // Expansion start should be the greater of initial_heap_end and current_top_aligned
     if new_top_aligned > current_top_aligned {
@@ -32,20 +32,15 @@ pub fn sys_brk(addr: usize) -> AxResult<isize> {
         let expand_size = new_top_aligned.saturating_sub(expand_start.as_usize());
 
         if expand_size > 0 {
-            let mut aspace = proc_data.aspace.lock();
-            if aspace
-                .map(
-                    expand_start,
-                    expand_size,
-                    MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
-                    true,
-                    Backend::new_alloc(expand_start, PageSize::Size4K),
-                )
-                .is_err()
-            {
+            if proc_data.aspace.lock().map(
+                expand_start,
+                expand_size,
+                MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
+                false,
+                Backend::new_alloc(expand_start, PageSize::Size4K),
+            ).is_err() {
                 return Ok(current_top as isize);
             }
-            drop(aspace);
         }
     }
 

--- a/api/src/syscall/mm/brk.rs
+++ b/api/src/syscall/mm/brk.rs
@@ -3,19 +3,21 @@ use axhal::paging::{MappingFlags, PageSize};
 use axmm::backend::Backend;
 use axtask::current;
 use memory_addr::{VirtAddr, align_up_4k};
-use starry_core::task::AsThread;
-use starry_core::config::{USER_HEAP_BASE, USER_HEAP_SIZE, USER_HEAP_SIZE_MAX};
+use starry_core::{
+    config::{USER_HEAP_BASE, USER_HEAP_SIZE, USER_HEAP_SIZE_MAX},
+    task::AsThread,
+};
 
 pub fn sys_brk(addr: usize) -> AxResult<isize> {
     let curr = current();
     let proc_data = &curr.as_thread().proc_data;
     let current_top = proc_data.get_heap_top() as usize;
     let heap_limit = USER_HEAP_BASE + USER_HEAP_SIZE_MAX;
-    
+
     if addr == 0 {
         return Ok(current_top as isize);
     }
-    
+
     if addr < USER_HEAP_BASE || addr > heap_limit {
         return Ok(current_top as isize);
     }
@@ -24,23 +26,27 @@ pub fn sys_brk(addr: usize) -> AxResult<isize> {
     let current_top_aligned = align_up_4k(current_top);
     // Initial heap region end address (already mapped during ELF loading)
     let initial_heap_end = USER_HEAP_BASE + USER_HEAP_SIZE;
-    
+
     // Only map new pages when expanding beyond already mapped region
     // Expansion start should be the greater of initial_heap_end and current_top_aligned
     if new_top_aligned > current_top_aligned {
         let expand_start = VirtAddr::from(initial_heap_end.max(current_top_aligned));
         let expand_size = new_top_aligned.saturating_sub(expand_start.as_usize());
 
-        if expand_size > 0 {
-            if proc_data.aspace.lock().map(
-                expand_start,
-                expand_size,
-                MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
-                false,
-                Backend::new_alloc(expand_start, PageSize::Size4K),
-            ).is_err() {
-                return Ok(current_top as isize);
-            }
+        if expand_size > 0
+            && proc_data
+                .aspace
+                .lock()
+                .map(
+                    expand_start,
+                    expand_size,
+                    MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
+                    false,
+                    Backend::new_alloc(expand_start, PageSize::Size4K),
+                )
+                .is_err()
+        {
+            return Ok(current_top as isize);
         }
     }
 

--- a/core/src/config/aarch64.rs
+++ b/core/src/config/aarch64.rs
@@ -21,5 +21,5 @@ pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
-/// The address of signal trampoline (placed at top of user space).
-pub const SIGNAL_TRAMPOLINE: usize = USER_SPACE_BASE + USER_SPACE_SIZE - 0x1000;
+/// The address of signal trampoline (placed at top of user heap).
+pub const SIGNAL_TRAMPOLINE: usize = 0x6000_1000;

--- a/core/src/config/aarch64.rs
+++ b/core/src/config/aarch64.rs
@@ -21,5 +21,5 @@ pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
-/// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;
+/// The address of signal trampoline (placed at top of user space).
+pub const SIGNAL_TRAMPOLINE: usize = USER_SPACE_BASE + USER_SPACE_SIZE - 0x1000;

--- a/core/src/config/aarch64.rs
+++ b/core/src/config/aarch64.rs
@@ -15,9 +15,11 @@ pub const USER_STACK_SIZE: usize = 0x8_0000;
 pub const USER_HEAP_BASE: usize = 0x4000_0000;
 /// The size of the user heap.
 pub const USER_HEAP_SIZE: usize = 0x1_0000;
+/// The maximum size of the user heap (for brk expansion).
+pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;

--- a/core/src/config/loongarch64.rs
+++ b/core/src/config/loongarch64.rs
@@ -21,5 +21,5 @@ pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;  // 512MB
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
-/// The address of signal trampoline (placed at top of user space).
-pub const SIGNAL_TRAMPOLINE: usize = USER_SPACE_BASE + USER_SPACE_SIZE - 0x1000;
+/// The address of signal trampoline (placed at top of user heap).
+pub const SIGNAL_TRAMPOLINE: usize = 0x6000_1000;

--- a/core/src/config/loongarch64.rs
+++ b/core/src/config/loongarch64.rs
@@ -14,10 +14,12 @@ pub const USER_STACK_SIZE: usize = 0x8_0000;
 /// The lowest address of the user heap.
 pub const USER_HEAP_BASE: usize = 0x4000_0000;
 /// The size of the user heap.
-pub const USER_HEAP_SIZE: usize = 0x1_0000;
+pub const USER_HEAP_SIZE: usize = 0x1_0000;  // 64KB
+/// The maximum size of the user heap (for brk expansion).
+pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;  // 512MB
 
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;

--- a/core/src/config/loongarch64.rs
+++ b/core/src/config/loongarch64.rs
@@ -21,5 +21,5 @@ pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;  // 512MB
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
-/// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;
+/// The address of signal trampoline (placed at top of user space).
+pub const SIGNAL_TRAMPOLINE: usize = USER_SPACE_BASE + USER_SPACE_SIZE - 0x1000;

--- a/core/src/config/riscv64.rs
+++ b/core/src/config/riscv64.rs
@@ -21,5 +21,5 @@ pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
-/// The address of signal trampoline (placed at top of user space).
-pub const SIGNAL_TRAMPOLINE: usize = USER_SPACE_BASE + USER_SPACE_SIZE - 0x1000;
+/// The address of signal trampoline (placed at top of user heap).
+pub const SIGNAL_TRAMPOLINE: usize = 0x6000_1000;

--- a/core/src/config/riscv64.rs
+++ b/core/src/config/riscv64.rs
@@ -21,5 +21,5 @@ pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
-/// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;
+/// The address of signal trampoline (placed at top of user space).
+pub const SIGNAL_TRAMPOLINE: usize = USER_SPACE_BASE + USER_SPACE_SIZE - 0x1000;

--- a/core/src/config/riscv64.rs
+++ b/core/src/config/riscv64.rs
@@ -15,9 +15,11 @@ pub const USER_STACK_SIZE: usize = 0x8_0000;
 pub const USER_HEAP_BASE: usize = 0x4000_0000;
 /// The size of the user heap.
 pub const USER_HEAP_SIZE: usize = 0x1_0000;
+/// The maximum size of the user heap (for brk expansion).
+pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;

--- a/core/src/config/x86_64.rs
+++ b/core/src/config/x86_64.rs
@@ -21,5 +21,5 @@ pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
-/// The address of signal trampoline (placed at top of user space).
-pub const SIGNAL_TRAMPOLINE: usize = USER_SPACE_BASE + USER_SPACE_SIZE - 0x1000;
+/// The address of signal trampoline (placed at top of user heap).
+pub const SIGNAL_TRAMPOLINE: usize = 0x6000_1000;

--- a/core/src/config/x86_64.rs
+++ b/core/src/config/x86_64.rs
@@ -21,5 +21,5 @@ pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
-/// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;
+/// The address of signal trampoline (placed at top of user space).
+pub const SIGNAL_TRAMPOLINE: usize = USER_SPACE_BASE + USER_SPACE_SIZE - 0x1000;

--- a/core/src/config/x86_64.rs
+++ b/core/src/config/x86_64.rs
@@ -15,9 +15,11 @@ pub const USER_STACK_SIZE: usize = 0x8_0000;
 pub const USER_HEAP_BASE: usize = 0x4000_0000;
 /// The size of the user heap.
 pub const USER_HEAP_SIZE: usize = 0x1_0000;
+/// The maximum size of the user heap (for brk expansion).
+pub const USER_HEAP_SIZE_MAX: usize = 0x2000_0000;
 
 /// The base address for user interpreter.
 pub const USER_INTERP_BASE: usize = 0x400_0000;
 
 /// The address of signal trampoline.
-pub const SIGNAL_TRAMPOLINE: usize = 0x4001_0000;
+pub const SIGNAL_TRAMPOLINE: usize = USER_STACK_TOP - USER_STACK_SIZE - 0x1000;


### PR DESCRIPTION
The original brk implementation had several issues:
1. Never actually mapped pages - only updated the heap_top pointer
2. Limit was USER_HEAP_SIZE (64KB), too small for real programs
3. Did not track initial heap region, causing double-mapping errors

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributing guide: https://github.com/Starry-OS/StarryOS?tab=contributing-ov-file#contributing-guide

Before submitting the PR, please ensure that your PR satisfies these requirements:
- Code formatted with `cargo fmt`
- Passed `cargo clippy` checks
- PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- Updated relevant documentation (if applicable)
-->

<!--
Related issues (if applicable)

If your PR solves one or more specific issues, you may link them here.
-->


## Implementation

<!--
Describe how you implemented it. What design decisions did you make and why?

If there are any trade-offs or limitations, please describe them here.
-->

1. brk Syscall Double-Mapping Issue

**File**: `api/src/syscall/mm/brk.rs`

**Bug Description**:
The original `brk` implementation did not properly track the initial heap region that was already mapped during ELF loading. When a process called `brk` to expand the heap, it would attempt to map pages that were already mapped, causing `AlreadyExists` errors.

**Fix**:
- Track `initial_heap_end` (USER_HEAP_BASE + USER_HEAP_SIZE) as the end of the pre-mapped region
- Use `initial_heap_end.max(current_top_aligned)` as the expansion start point
- Only map new pages when expanding beyond the already mapped region
- Use `saturating_sub` to avoid negative sizes

2. Added USER_HEAP_SIZE_MAX Configuration

**Files**:
- `core/src/config/aarch64.rs`
- `core/src/config/loongarch64.rs`
- `core/src/config/riscv64.rs`
- `core/src/config/x86_64.rs`

**Description**:
Added `USER_HEAP_SIZE_MAX` (512MB) constant to limit maximum heap expansion via `brk`. This prevents unlimited heap growth.