### PR TITLE
fix(mm): add VmIo retry logic for lazy allocation

### DIFF
--- a/api/src/io.rs
+++ b/api/src/io.rs
@@ -148,7 +148,7 @@ impl Write for IoVectorBufIo {
             if len == 0 {
                 break;
             }
-            
+
             // Pre-populate pages to support lazy allocation
             let dst_ptr = iov.iov_base.wrapping_add(self.offset);
             let start_addr = VirtAddr::from_ptr_of(dst_ptr);
@@ -168,11 +168,8 @@ impl Write for IoVectorBufIo {
                     return Err(AxError::BadAddress);
                 }
             }
-            
-            vm_write_slice(
-                dst_ptr,
-                &buf[count..count + len],
-            )?;
+
+            vm_write_slice(dst_ptr, &buf[count..count + len])?;
             self.offset += len;
             self.inner.len -= len;
             count += len;

--- a/api/src/io.rs
+++ b/api/src/io.rs
@@ -1,11 +1,8 @@
 use core::mem::{self, MaybeUninit};
 
 use axerrno::{AxError, AxResult};
-use axhal::paging::MappingFlags;
 use axio::{Buf, BufMut, Read, Write};
 use bytemuck::AnyBitPattern;
-use memory_addr::{MemoryAddr, VirtAddr};
-use starry_core::task::AsThread;
 use starry_vm::{VmPtr, vm_read_slice, vm_write_slice};
 
 #[repr(C)]
@@ -148,28 +145,10 @@ impl Write for IoVectorBufIo {
             if len == 0 {
                 break;
             }
-
-            // Pre-populate pages to support lazy allocation
-            let dst_ptr = iov.iov_base.wrapping_add(self.offset);
-            let start_addr = VirtAddr::from_ptr_of(dst_ptr);
-            {
-                let curr = axtask::current();
-                let mut aspace = curr.as_thread().proc_data.aspace.lock();
-                let page_start = start_addr.align_down_4k();
-                let page_end = (start_addr + len).align_up_4k();
-                if aspace
-                    .populate_area(
-                        page_start,
-                        page_end - page_start,
-                        MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
-                    )
-                    .is_err()
-                {
-                    return Err(AxError::BadAddress);
-                }
-            }
-
-            vm_write_slice(dst_ptr, &buf[count..count + len])?;
+            vm_write_slice(
+                iov.iov_base.wrapping_add(self.offset),
+                &buf[count..count + len],
+            )?;
             self.offset += len;
             self.inner.len -= len;
             count += len;

--- a/api/src/io.rs
+++ b/api/src/io.rs
@@ -157,11 +157,14 @@ impl Write for IoVectorBufIo {
                 let mut aspace = curr.as_thread().proc_data.aspace.lock();
                 let page_start = start_addr.align_down_4k();
                 let page_end = (start_addr + len).align_up_4k();
-                if let Err(_) = aspace.populate_area(
-                    page_start,
-                    page_end - page_start,
-                    MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
-                ) {
+                if aspace
+                    .populate_area(
+                        page_start,
+                        page_end - page_start,
+                        MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
+                    )
+                    .is_err()
+                {
                     return Err(AxError::BadAddress);
                 }
             }

--- a/api/src/mm.rs
+++ b/api/src/mm.rs
@@ -333,19 +333,6 @@ impl Write for VmBytesMut {
         if len == 0 {
             return Ok(0);
         }
-
-        let start_addr = VirtAddr::from_ptr_of(self.ptr);
-        // Ensure pages are allocated (for lazy-allocated stack/heap regions)
-        if check_region(
-            start_addr,
-            Layout::from_size_align(len, 1).unwrap(),
-            MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
-        )
-        .is_err()
-        {
-            return Err(axio::Error::InvalidData);
-        }
-
         vm_write_slice(self.ptr, &buf[..len])?;
         self.ptr = self.ptr.wrapping_add(len);
         self.len -= len;

--- a/api/src/mm.rs
+++ b/api/src/mm.rs
@@ -336,11 +336,13 @@ impl Write for VmBytesMut {
         
         let start_addr = VirtAddr::from_ptr_of(self.ptr);
         // Ensure pages are allocated (for lazy-allocated stack/heap regions)
-        if let Err(_) = check_region(
+        if check_region(
             start_addr,
             Layout::from_size_align(len, 1).unwrap(),
             MappingFlags::READ | MappingFlags::WRITE | MappingFlags::USER,
-        ) {
+        )
+        .is_err()
+        {
             return Err(axio::Error::InvalidData);
         }
         

--- a/api/src/mm.rs
+++ b/api/src/mm.rs
@@ -333,7 +333,7 @@ impl Write for VmBytesMut {
         if len == 0 {
             return Ok(0);
         }
-        
+
         let start_addr = VirtAddr::from_ptr_of(self.ptr);
         // Ensure pages are allocated (for lazy-allocated stack/heap regions)
         if check_region(
@@ -345,7 +345,7 @@ impl Write for VmBytesMut {
         {
             return Err(axio::Error::InvalidData);
         }
-        
+
         vm_write_slice(self.ptr, &buf[..len])?;
         self.ptr = self.ptr.wrapping_add(len);
         self.len -= len;


### PR DESCRIPTION
VmIo Lazy Allocation Failure

**Files**:
- `core/src/mm.rs`
- `api/src/io.rs`
- `api/src/mm.rs`

**Bug Description**:
When the kernel tried to read/write user memory that was lazily allocated but not yet faulted in, the operation would fail with `AccessDenied` instead of triggering page fault handling.

**Fix**:
Added retry logic with page population:
1. First attempt the read/write
2. If failed, calculate the faulting address from the failure offset
3. Call `populate_area` to ensure the pages are allocated
4. Retry the read/write operation