### PR TITLE
Fix waitpid UAF, correct PR_SET_MM handling, add mincore stub

### DIFF
--- a/api/src/syscall/fs/io.rs
+++ b/api/src/syscall/fs/io.rs
@@ -408,10 +408,9 @@ pub fn sys_splice(
             }
             has_pipe = true;
         }
-        if let Ok(file) = File::from_fd(fd_in) {
-            if file.inner().is_path() {
-                return Err(AxError::InvalidInput);
-            }
+        match File::from_fd(fd_in) {
+            Ok(file) if file.inner().is_path() => return Err(AxError::InvalidInput),
+            _ => {}
         }
         SendFile::Direct(get_file_like(fd_in)?)
     };
@@ -428,10 +427,11 @@ pub fn sys_splice(
             }
             has_pipe = true;
         }
-        if let Ok(file) = File::from_fd(fd_out) {
-            if file.inner().access(FileFlags::APPEND).is_ok() {
+        match File::from_fd(fd_out) {
+            Ok(file) if file.inner().access(FileFlags::APPEND).is_ok() => {
                 return Err(AxError::InvalidInput);
             }
+            _ => {}
         }
         let f = get_file_like(fd_out)?;
         f.write(&mut b"".as_slice().into())?;

--- a/api/src/syscall/fs/io.rs
+++ b/api/src/syscall/fs/io.rs
@@ -408,10 +408,10 @@ pub fn sys_splice(
             }
             has_pipe = true;
         }
-        if let Ok(file) = File::from_fd(fd_in)
-            && file.inner().is_path()
-        {
-            return Err(AxError::InvalidInput);
+        if let Ok(file) = File::from_fd(fd_in) {
+            if file.inner().is_path() {
+                return Err(AxError::InvalidInput);
+            }
         }
         SendFile::Direct(get_file_like(fd_in)?)
     };
@@ -428,10 +428,10 @@ pub fn sys_splice(
             }
             has_pipe = true;
         }
-        if let Ok(file) = File::from_fd(fd_out)
-            && file.inner().access(FileFlags::APPEND).is_ok()
-        {
-            return Err(AxError::InvalidInput);
+        if let Ok(file) = File::from_fd(fd_out) {
+            if file.inner().access(FileFlags::APPEND).is_ok() {
+                return Err(AxError::InvalidInput);
+            }
         }
         let f = get_file_like(fd_out)?;
         f.write(&mut b"".as_slice().into())?;

--- a/api/src/syscall/io_mpx/select.rs
+++ b/api/src/syscall/io_mpx/select.rs
@@ -114,23 +114,23 @@ fn do_select(
                 let mut res = 0usize;
                 for ((fd, interested), index) in fds.0.iter().zip(fd_indices.iter().copied()) {
                     let events = fd.poll() & *interested;
-                    if events.contains(IoEvents::IN)
-                        && let Some(set) = readfds.as_deref_mut()
-                    {
-                        res += 1;
-                        unsafe { FD_SET(index as _, set) };
+                    if events.contains(IoEvents::IN) {
+                        if let Some(set) = readfds.as_deref_mut() {
+                            res += 1;
+                            unsafe { FD_SET(index as _, set) };
+                        }
                     }
-                    if events.contains(IoEvents::OUT)
-                        && let Some(set) = writefds.as_deref_mut()
-                    {
-                        res += 1;
-                        unsafe { FD_SET(index as _, set) };
+                    if events.contains(IoEvents::OUT) {
+                        if let Some(set) = writefds.as_deref_mut() {
+                            res += 1;
+                            unsafe { FD_SET(index as _, set) };
+                        }
                     }
-                    if events.contains(IoEvents::ERR)
-                        && let Some(set) = exceptfds.as_deref_mut()
-                    {
-                        res += 1;
-                        unsafe { FD_SET(index as _, set) };
+                    if events.contains(IoEvents::ERR) {
+                        if let Some(set) = exceptfds.as_deref_mut() {
+                            res += 1;
+                            unsafe { FD_SET(index as _, set) };
+                        }
                     }
                 }
                 if res > 0 {

--- a/api/src/syscall/io_mpx/select.rs
+++ b/api/src/syscall/io_mpx/select.rs
@@ -114,26 +114,23 @@ fn do_select(
                 let mut res = 0usize;
                 for ((fd, interested), index) in fds.0.iter().zip(fd_indices.iter().copied()) {
                     let events = fd.poll() & *interested;
-                    match (events.contains(IoEvents::IN), readfds.as_deref_mut()) {
-                        (true, Some(set)) => {
-                            res += 1;
-                            unsafe { FD_SET(index as _, set) };
-                        }
-                        _ => {}
+                    if let (true, Some(set)) =
+                        (events.contains(IoEvents::IN), readfds.as_deref_mut())
+                    {
+                        res += 1;
+                        unsafe { FD_SET(index as _, set) };
                     }
-                    match (events.contains(IoEvents::OUT), writefds.as_deref_mut()) {
-                        (true, Some(set)) => {
-                            res += 1;
-                            unsafe { FD_SET(index as _, set) };
-                        }
-                        _ => {}
+                    if let (true, Some(set)) =
+                        (events.contains(IoEvents::OUT), writefds.as_deref_mut())
+                    {
+                        res += 1;
+                        unsafe { FD_SET(index as _, set) };
                     }
-                    match (events.contains(IoEvents::ERR), exceptfds.as_deref_mut()) {
-                        (true, Some(set)) => {
-                            res += 1;
-                            unsafe { FD_SET(index as _, set) };
-                        }
-                        _ => {}
+                    if let (true, Some(set)) =
+                        (events.contains(IoEvents::ERR), exceptfds.as_deref_mut())
+                    {
+                        res += 1;
+                        unsafe { FD_SET(index as _, set) };
                     }
                 }
                 if res > 0 {

--- a/api/src/syscall/io_mpx/select.rs
+++ b/api/src/syscall/io_mpx/select.rs
@@ -114,23 +114,26 @@ fn do_select(
                 let mut res = 0usize;
                 for ((fd, interested), index) in fds.0.iter().zip(fd_indices.iter().copied()) {
                     let events = fd.poll() & *interested;
-                    if events.contains(IoEvents::IN) {
-                        if let Some(set) = readfds.as_deref_mut() {
+                    match (events.contains(IoEvents::IN), readfds.as_deref_mut()) {
+                        (true, Some(set)) => {
                             res += 1;
                             unsafe { FD_SET(index as _, set) };
                         }
+                        _ => {}
                     }
-                    if events.contains(IoEvents::OUT) {
-                        if let Some(set) = writefds.as_deref_mut() {
+                    match (events.contains(IoEvents::OUT), writefds.as_deref_mut()) {
+                        (true, Some(set)) => {
                             res += 1;
                             unsafe { FD_SET(index as _, set) };
                         }
+                        _ => {}
                     }
-                    if events.contains(IoEvents::ERR) {
-                        if let Some(set) = exceptfds.as_deref_mut() {
+                    match (events.contains(IoEvents::ERR), exceptfds.as_deref_mut()) {
+                        (true, Some(set)) => {
                             res += 1;
                             unsafe { FD_SET(index as _, set) };
                         }
+                        _ => {}
                     }
                 }
                 if res > 0 {

--- a/api/src/syscall/mm/mmap.rs
+++ b/api/src/syscall/mm/mmap.rs
@@ -335,3 +335,9 @@ pub fn sys_mlock(addr: usize, length: usize) -> AxResult<isize> {
 pub fn sys_mlock2(_addr: usize, _length: usize, _flags: u32) -> AxResult<isize> {
     Ok(0)
 }
+
+/// Check whether pages are resident in memory.
+/// Returns ENOSYS (Unsupported) to let programs use fallback logic.
+pub fn sys_mincore(_addr: usize, _length: usize, _vec: usize) -> AxResult<isize> {
+    Err(AxError::Unsupported)
+}

--- a/api/src/syscall/mod.rs
+++ b/api/src/syscall/mod.rs
@@ -357,6 +357,7 @@ pub fn handle_syscall(uctx: &mut UserContext) {
         Sysno::msync => sys_msync(uctx.arg0(), uctx.arg1() as _, uctx.arg2() as _),
         Sysno::mlock => sys_mlock(uctx.arg0(), uctx.arg1() as _),
         Sysno::mlock2 => sys_mlock2(uctx.arg0(), uctx.arg1() as _, uctx.arg2() as _),
+        Sysno::mincore => sys_mincore(uctx.arg0(), uctx.arg1() as _, uctx.arg2()),
 
         // task info
         Sysno::getpid => sys_getpid(),

--- a/api/src/syscall/resources.rs
+++ b/api/src/syscall/resources.rs
@@ -105,13 +105,11 @@ pub fn sys_getrusage(who: i32, usage: *mut rusage) -> AxResult<isize> {
                 .proc
                 .threads()
                 .into_iter()
-                .fold(Rusage::default(), |acc, child| {
-                    if let Ok(task) = get_task(child) {
-                        if !curr.ptr_eq(&task) {
-                            return acc.collate(Rusage::from_thread(task.as_thread()));
-                        }
+                .fold(Rusage::default(), |acc, child| match get_task(child) {
+                    Ok(task) if !curr.ptr_eq(&task) => {
+                        acc.collate(Rusage::from_thread(task.as_thread()))
                     }
-                    acc
+                    _ => acc,
                 })
         }
         RUSAGE_THREAD => Rusage::from_thread(thr),

--- a/api/src/syscall/resources.rs
+++ b/api/src/syscall/resources.rs
@@ -106,13 +106,12 @@ pub fn sys_getrusage(who: i32, usage: *mut rusage) -> AxResult<isize> {
                 .threads()
                 .into_iter()
                 .fold(Rusage::default(), |acc, child| {
-                    if let Ok(task) = get_task(child)
-                        && !curr.ptr_eq(&task)
-                    {
-                        acc.collate(Rusage::from_thread(task.as_thread()))
-                    } else {
-                        acc
+                    if let Ok(task) = get_task(child) {
+                        if !curr.ptr_eq(&task) {
+                            return acc.collate(Rusage::from_thread(task.as_thread()));
+                        }
                     }
+                    acc
                 })
         }
         RUSAGE_THREAD => Rusage::from_thread(thr),

--- a/api/src/syscall/task/ctl.rs
+++ b/api/src/syscall/task/ctl.rs
@@ -99,12 +99,26 @@ pub fn sys_prctl(
         }
         PR_SET_SECCOMP => {}
         PR_MCE_KILL => {}
-        PR_SET_MM_START_CODE
-        | PR_SET_MM_END_CODE
-        | PR_SET_MM_START_DATA
-        | PR_SET_MM_END_DATA
-        | PR_SET_MM_START_BRK
-        | PR_SET_MM_START_STACK => {}
+        PR_SET_MM => match arg2 as u32 {
+            PR_SET_MM_START_CODE
+            | PR_SET_MM_END_CODE
+            | PR_SET_MM_START_DATA
+            | PR_SET_MM_END_DATA
+            | PR_SET_MM_START_BRK
+            | PR_SET_MM_BRK
+            | PR_SET_MM_START_STACK
+            | PR_SET_MM_ARG_START
+            | PR_SET_MM_ARG_END
+            | PR_SET_MM_ENV_START
+            | PR_SET_MM_ENV_END
+            | PR_SET_MM_AUXV
+            | PR_SET_MM_EXE_FILE
+            | PR_SET_MM_MAP => {}
+            _ => {
+                warn!("sys_prctl: unsupported PR_SET_MM sub-option {:#x}", arg2);
+                return Err(AxError::InvalidInput);
+            }
+        },
         _ => {
             warn!("sys_prctl: unsupported option {option}");
             return Err(AxError::InvalidInput);

--- a/api/src/syscall/task/wait.rs
+++ b/api/src/syscall/task/wait.rs
@@ -90,13 +90,15 @@ pub fn sys_waitpid(pid: i32, exit_code: *mut i32, options: u32) -> AxResult<isiz
 
     let check_children = || {
         if let Some(child) = children.iter().find(|child| child.is_zombie()) {
+            let child_pid = child.pid();
+            let child_exit_code = child.exit_code();
             if !options.contains(WaitOptions::WNOWAIT) {
                 child.free();
             }
             if let Some(exit_code) = exit_code.nullable() {
-                exit_code.vm_write(child.exit_code())?;
+                exit_code.vm_write(child_exit_code)?;
             }
-            Ok(Some(child.pid() as _))
+            Ok(Some(child_pid as _))
         } else if options.contains(WaitOptions::WNOHANG) {
             Ok(Some(0))
         } else {


### PR DESCRIPTION
1. read child pid/exit_code before free in waitpid

In sys_waitpid, child.pid() and child.exit_code() were read after calling child.free(), which could lead to use-after-free issues.

Fix: Read pid and exit_code before calling free().

2. PR_SET_MM Handling in prctl

**File**: `api/src/syscall/task/ctl.rs`

**Bug Description**:
The `prctl` syscall was incorrectly matching `PR_SET_MM_*` constants at the top level instead of as sub-options of `PR_SET_MM`.

**Fix**:
Restructured the match to properly handle `PR_SET_MM` with its sub-options:
```rust
PR_SET_MM => match arg2 as u32 {
    PR_SET_MM_START_CODE | PR_SET_MM_END_CODE | ... => {}
    _ => return Err(AxError::InvalidInput),
}
```
3. Added mincore Syscall Stub

**File**: `api/src/syscall/mm/mmap.rs`

**Description**:
Added `sys_mincore` that returns `ENOSYS` (Unsupported). This is safer than returning incorrect data and lets programs use fallback logic.