### PR TITLE
fix(smp): move `accessing_user_memory` into thread data

### DIFF
--- a/api/src/mm.rs
+++ b/api/src/mm.rs
@@ -16,7 +16,7 @@ use axio::prelude::*;
 use axtask::current;
 use memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
 use starry_core::{
-    mm::{access_user_memory, is_accessing_user_memory},
+    mm::access_user_memory,
     task::AsThread,
 };
 use starry_vm::{vm_load_until_nul, vm_read_slice, vm_write_slice};
@@ -240,14 +240,15 @@ pub(crate) use nullable;
 #[register_trap_handler(PAGE_FAULT)]
 fn handle_page_fault(vaddr: VirtAddr, access_flags: MappingFlags) -> bool {
     debug!("Page fault at {vaddr:#x}, access_flags: {access_flags:#x?}");
-    if unlikely(!is_accessing_user_memory()) {
-        return false;
-    }
 
     let curr = current();
     let Some(thr) = curr.try_as_thread() else {
         return false;
     };
+
+    if unlikely(!thr.is_accessing_user_memory()) {
+        return false;
+    }
 
     thr.proc_data
         .aspace

--- a/api/src/mm.rs
+++ b/api/src/mm.rs
@@ -15,10 +15,7 @@ use axhal::{
 use axio::prelude::*;
 use axtask::current;
 use memory_addr::{MemoryAddr, PAGE_SIZE_4K, VirtAddr};
-use starry_core::{
-    mm::access_user_memory,
-    task::AsThread,
-};
+use starry_core::{mm::access_user_memory, task::AsThread};
 use starry_vm::{vm_load_until_nul, vm_read_slice, vm_write_slice};
 
 fn check_region(start: VirtAddr, layout: Layout, access_flags: MappingFlags) -> AxResult<()> {

--- a/core/src/mm.rs
+++ b/core/src/mm.rs
@@ -6,7 +6,6 @@ use core::{
     hint::unlikely,
     iter,
     mem::MaybeUninit,
-    sync::atomic::{AtomicUsize, Ordering},
 };
 
 use axerrno::{AxError, AxResult};
@@ -19,6 +18,7 @@ use axhal::{
 };
 use axmm::{AddrSpace, backend::Backend};
 use axsync::Mutex;
+use axtask::current;
 use extern_trait::extern_trait;
 use kernel_elf_parser::{AuxEntry, ELFHeaders, ELFHeadersBuilder, ELFParser, app_stack_region};
 use kernel_guard::IrqSave;
@@ -27,7 +27,10 @@ use ouroboros::self_referencing;
 use starry_vm::{VmError, VmIo, VmResult};
 use uluru::LRUCache;
 
-use crate::config::{USER_SPACE_BASE, USER_SPACE_SIZE};
+use crate::{
+    config::{USER_SPACE_BASE, USER_SPACE_SIZE},
+    task::AsThread,
+};
 
 /// Creates a new empty user address space.
 pub fn new_user_aspace_empty() -> AxResult<AddrSpace> {
@@ -350,20 +353,18 @@ pub fn load_user_app(
     Ok((entry, user_sp))
 }
 
-static ACCESSING_USER_MEM: AtomicUsize = AtomicUsize::new(0);
-
 /// Enables scoped access into user memory, allowing page faults to occur inside
 /// kernel.
 pub fn access_user_memory<R>(f: impl FnOnce() -> R) -> R {
-    ACCESSING_USER_MEM.fetch_add(1, Ordering::AcqRel);
-    let result = f();
-    ACCESSING_USER_MEM.fetch_sub(1, Ordering::AcqRel);
-    result
-}
+    let curr = current();
+    let Some(thr) = curr.try_as_thread() else {
+        panic!("access_user_memory called outside of thread context");
+    };
 
-/// Check if the current thread is accessing user memory.
-pub fn is_accessing_user_memory() -> bool {
-    ACCESSING_USER_MEM.load(Ordering::Acquire) > 0
+    thr.set_accessing_user_memory(true);
+    let result = f();
+    thr.set_accessing_user_memory(false);
+    result
 }
 
 #[allow(dead_code)]

--- a/core/src/mm.rs
+++ b/core/src/mm.rs
@@ -1,12 +1,7 @@
 //! User address space management.
 
 use alloc::{borrow::ToOwned, string::String, vec, vec::Vec};
-use core::{
-    ffi::CStr,
-    hint::unlikely,
-    iter,
-    mem::MaybeUninit,
-};
+use core::{ffi::CStr, hint::unlikely, iter, mem::MaybeUninit};
 
 use axerrno::{AxError, AxResult};
 use axfs::{CachedFile, FS_CONTEXT, FileBackend};

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -85,7 +85,6 @@ pub struct Thread {
 
     /// Indicates whether the thread is currently accessing user memory.
     accessing_user_memory: AtomicBool,
-
 }
 
 impl Thread {
@@ -155,7 +154,6 @@ impl Thread {
         self.accessing_user_memory
             .store(accessing, Ordering::Release);
     }
-
 }
 
 #[extern_trait]

--- a/core/src/task.rs
+++ b/core/src/task.rs
@@ -82,6 +82,10 @@ pub struct Thread {
 
     /// Ready to exit
     exit: AtomicBool,
+
+    /// Indicates whether the thread is currently accessing user memory.
+    accessing_user_memory: AtomicBool,
+
 }
 
 impl Thread {
@@ -95,6 +99,7 @@ impl Thread {
             time: AssumeSync(RefCell::new(TimeManager::new())),
             oom_score_adj: AtomicI32::new(200),
             exit: AtomicBool::new(false),
+            accessing_user_memory: AtomicBool::new(false),
         })
     }
 
@@ -139,6 +144,18 @@ impl Thread {
     pub fn set_exit(&self) {
         self.exit.store(true, Ordering::Release);
     }
+
+    /// Check if the thread is accessing user memory.
+    pub fn is_accessing_user_memory(&self) -> bool {
+        self.accessing_user_memory.load(Ordering::Acquire)
+    }
+
+    /// Set the accessing user memory flag.
+    pub fn set_accessing_user_memory(&self, accessing: bool) {
+        self.accessing_user_memory
+            .store(accessing, Ordering::Release);
+    }
+
 }
 
 #[extern_trait]


### PR DESCRIPTION
Alternative to #94 
Closes: #102