### PR TITLE
Various fixes to memory backend

### DIFF
--- a/kernel/src/mm/aspace/backend/file.rs
+++ b/kernel/src/mm/aspace/backend/file.rs
@@ -33,9 +33,12 @@ impl Drop for FileBackendInner {
     }
 }
 impl FileBackendInner {
-    pub fn register_listener(self: &Arc<Self>, aspace: &Arc<Mutex<AddrSpace>>) -> usize {
+    pub fn register_listener(self: &Arc<Self>, aspace: &Arc<Mutex<AddrSpace>>) {
+        if self.handle.load(Ordering::Acquire) != 0 {
+            panic!("Listener already registered");
+        }
         let aspace = Arc::downgrade(aspace);
-        self.cache.add_evict_listener({
+        let handle = self.cache.add_evict_listener({
             let this = Arc::downgrade(self);
             move |pn, _page| {
                 let Some(this) = this.upgrade() else {
@@ -53,7 +56,8 @@ impl FileBackendInner {
                 };
                 this.on_evict(pn, &mut aspace);
             }
-        })
+        });
+        self.handle.store(handle, Ordering::Release);
     }
 
     fn on_evict(self: &Arc<Self>, pn: u32, aspace: &mut AddrSpace) {

--- a/kernel/src/mm/aspace/backend/mod.rs
+++ b/kernel/src/mm/aspace/backend/mod.rs
@@ -145,6 +145,12 @@ impl MappingBackend for Backend {
         new_flags: Self::Flags,
         pt: &mut Self::PageTable,
     ) -> bool {
-        pt.cursor().protect_region(start, size, new_flags).is_ok()
+        let range = VirtAddrRange::from_start_size(start, size);
+        let mut cursor = pt.cursor();
+        if let Err(err) = BackendOps::on_protect(self, range, new_flags, &mut cursor) {
+            warn!("Failed to protect area: {:?}", err);
+            return false;
+        }
+        cursor.protect_region(start, size, new_flags).is_ok()
     }
 }

--- a/kernel/src/mm/aspace/backend/shared.rs
+++ b/kernel/src/mm/aspace/backend/shared.rs
@@ -14,8 +14,9 @@ pub struct SharedPages {
 }
 impl SharedPages {
     pub fn new(size: usize, page_size: PageSize) -> AxResult<Self> {
-        let mut phys_pages = Vec::with_capacity(divide_page(size, page_size));
-        for _ in 0..phys_pages.capacity() {
+        let num_pages = divide_page(size, page_size);
+        let mut phys_pages = Vec::with_capacity(num_pages);
+        for _ in 0..num_pages {
             match alloc_frame(true, page_size) {
                 Ok(frame) => phys_pages.push(frame),
                 Err(e) => {

--- a/kernel/src/mm/aspace/backend/shared.rs
+++ b/kernel/src/mm/aspace/backend/shared.rs
@@ -14,10 +14,20 @@ pub struct SharedPages {
 }
 impl SharedPages {
     pub fn new(size: usize, page_size: PageSize) -> AxResult<Self> {
+        let mut phys_pages = Vec::with_capacity(divide_page(size, page_size));
+        for _ in 0..phys_pages.capacity() {
+            match alloc_frame(true, page_size) {
+                Ok(frame) => phys_pages.push(frame),
+                Err(e) => {
+                    for frame in phys_pages {
+                        dealloc_frame(frame, page_size);
+                    }
+                    return Err(e);
+                }
+            }
+        }
         Ok(Self {
-            phys_pages: (0..divide_page(size, page_size))
-                .map(|_| alloc_frame(true, page_size))
-                .collect::<AxResult<_>>()?,
+            phys_pages,
             size: page_size,
         })
     }

--- a/kernel/src/mm/aspace/backend/shared.rs
+++ b/kernel/src/mm/aspace/backend/shared.rs
@@ -15,22 +15,14 @@ pub struct SharedPages {
 impl SharedPages {
     pub fn new(size: usize, page_size: PageSize) -> AxResult<Self> {
         let num_pages = divide_page(size, page_size);
-        let mut phys_pages = Vec::with_capacity(num_pages);
-        for _ in 0..num_pages {
-            match alloc_frame(true, page_size) {
-                Ok(frame) => phys_pages.push(frame),
-                Err(e) => {
-                    for frame in phys_pages {
-                        dealloc_frame(frame, page_size);
-                    }
-                    return Err(e);
-                }
-            }
-        }
-        Ok(Self {
-            phys_pages,
+        let mut result = Self {
+            phys_pages: Vec::with_capacity(num_pages),
             size: page_size,
-        })
+        };
+        for _ in 0..num_pages {
+            result.phys_pages.push(alloc_frame(true, page_size)?);
+        }
+        Ok(result)
     }
 
     pub fn len(&self) -> usize {


### PR DESCRIPTION
## Description

While merging `axmm` into StarryOS in #118, Copilot spotted several flaws in the implementation:

- Evict listeners are not properly released
- `on_protect` method is not used
- `SharedBackend::new` does not rollback on error

## Implementation

This PR addresses the issues above.
