### PR TITLE
refactor: don't use arceos as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "arceos"]
-	path = arceos
-	url = https://github.com/Starry-OS/arceos
-	branch = dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,11 +4,44 @@ version = 4
 
 [[package]]
 name = "aarch64-cpu"
+version = "10.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a21cd0131c25c438e19cd6a774adf7e3f64f7f4d723022882facc2dee0f8bc9"
+dependencies = [
+ "tock-registers 0.9.0",
+]
+
+[[package]]
+name = "aarch64-cpu"
 version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44171e22925ec72b63d86747bc3655c7849a5b8d865c980222128839f45ac034"
 dependencies = [
  "tock-registers 0.10.1",
+]
+
+[[package]]
+name = "aarch64-cpu-ext"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dad5cf7342926ce1c375ec680834e56dd3cdbe8b7adf8a6f99b2854cc52c17"
+dependencies = [
+ "aarch64-cpu 10.0.0",
+ "tock-registers 0.10.1",
+]
+
+[[package]]
+name = "acpi"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ccf6d4e668d9babca9103f59f305d3bc55e24355cf166dbddf5a7a5e1243d06"
+dependencies = [
+ "bit_field",
+ "bitflags 2.11.0",
+ "byteorder",
+ "log",
+ "pci_types",
+ "spinning_top 0.3.0",
 ]
 
 [[package]]
@@ -42,6 +75,28 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "aml"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f8cba7d4260ea05671dda81029f6f718b54402a4ec926a0d9a41bdbb96b415"
+dependencies = [
+ "bit_field",
+ "bitvec",
+ "byteorder",
+ "log",
+ "spinning_top 0.2.5",
+]
+
+[[package]]
+name = "ansi_rgb"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a730095eb14ee842a0f1e68504b85c8d4a19b1ef2ac2a9b4debf0ed982f9b08a"
+dependencies = [
+ "rgb",
+]
 
 [[package]]
 name = "anstream"
@@ -94,16 +149,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "arm-gic-driver"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e30c6a0ffd23095c69f48afd996eb51156b2511b52a01bdbb0b418fdfd1d458c"
 dependencies = [
- "aarch64-cpu",
+ "aarch64-cpu 11.2.0",
  "bitflags 2.11.0",
  "enum_dispatch",
  "log",
  "paste",
+ "tock-registers 0.10.1",
+]
+
+[[package]]
+name = "arm-gic-driver"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dda00d35b3c85f4e994746587c4579e63c0ba350b843fca96d6531b609292ae"
+dependencies = [
+ "aarch64-cpu 11.2.0",
+ "bitflags 2.11.0",
+ "enum_dispatch",
+ "log",
+ "paste",
+ "rdif-intc",
  "tock-registers 0.10.1",
 ]
 
@@ -130,6 +206,12 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-any"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
 
 [[package]]
 name = "async-channel"
@@ -171,7 +253,8 @@ dependencies = [
 
 [[package]]
 name = "axalloc"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axallocator",
  "axbacktrace",
@@ -213,7 +296,8 @@ dependencies = [
 
 [[package]]
 name = "axconfig"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axconfig-macros",
 ]
@@ -242,11 +326,11 @@ dependencies = [
 
 [[package]]
 name = "axcpu"
-version = "0.3.0-preview.5"
+version = "0.3.0-preview.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf99fd0321a4e2a0eb1fb2a1a53ae47ea10a9c31a969545575ce302291934ea0"
+checksum = "61dc8203ac5b80e4aa613c1139b1c69b908aededadd1ae7c55b41da06084a2ad"
 dependencies = [
- "aarch64-cpu",
+ "aarch64-cpu 11.2.0",
  "axbacktrace",
  "cfg-if",
  "lazyinit",
@@ -266,7 +350,8 @@ dependencies = [
 
 [[package]]
 name = "axdisplay"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axdriver",
  "axsync",
@@ -276,7 +361,8 @@ dependencies = [
 
 [[package]]
 name = "axdriver"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axalloc",
  "axconfig",
@@ -362,7 +448,6 @@ dependencies = [
  "axdriver_display",
  "axdriver_input",
  "axdriver_net",
- "axdriver_vsock",
  "log",
  "virtio-drivers",
 ]
@@ -398,14 +483,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "axfatfs"
+version = "0.1.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bf1c27753a96a0f835cca49e6fb354912107d018c905d13c7eff39be757eb5a"
+dependencies = [
+ "bitflags 2.11.0",
+ "log",
+]
+
+[[package]]
 name = "axfeat"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axalloc",
  "axbacktrace",
  "axdisplay",
  "axdriver",
  "axfs",
+ "axfs-ng",
  "axhal",
  "axinput",
  "axlog",
@@ -418,7 +515,27 @@ dependencies = [
 
 [[package]]
 name = "axfs"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+dependencies = [
+ "axdriver",
+ "axerrno 0.2.2",
+ "axfatfs",
+ "axfs_devfs",
+ "axfs_ramfs",
+ "axfs_vfs",
+ "axio",
+ "cap_access",
+ "lazyinit",
+ "log",
+ "rsext4",
+ "spin 0.10.0",
+]
+
+[[package]]
+name = "axfs-ng"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axalloc",
  "axdriver",
@@ -459,14 +576,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "axfs_devfs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81b87ae981272ca8d5d8f106a4452c63f4b5ac36e17ee8f848ee1b250538b9f8"
+dependencies = [
+ "axfs_vfs",
+ "log",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "axfs_ramfs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f50c26614485d837a3fc09a92f24a226caddc25a30df7e6aaf4bd19b304c399"
+dependencies = [
+ "axfs_vfs",
+ "log",
+ "spin 0.9.8",
+]
+
+[[package]]
+name = "axfs_vfs"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcba2006898d7879d456a9c34b9c9460cb536f5bf69d1d5d7d0e0f19f073368d"
+dependencies = [
+ "axerrno 0.1.2",
+ "bitflags 2.11.0",
+ "log",
+]
+
+[[package]]
 name = "axhal"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axalloc",
  "axconfig",
  "axcpu",
  "axplat",
  "axplat-aarch64-qemu-virt",
+ "axplat-dyn",
  "axplat-loongarch64-qemu-virt",
  "axplat-riscv64-qemu-virt",
  "axplat-x86-pc",
@@ -474,7 +626,6 @@ dependencies = [
  "fdt-parser",
  "heapless 0.9.2",
  "kernel_guard",
- "lazyinit",
  "linkme",
  "log",
  "memory_addr",
@@ -485,7 +636,8 @@ dependencies = [
 
 [[package]]
 name = "axinput"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axdriver",
  "axsync",
@@ -506,8 +658,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "axklib"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03bf328ee0dd583179ce7108584ec69da10e06bd4beb4d6acac7f6cb33754dab"
+dependencies = [
+ "axerrno 0.2.2",
+ "memory_addr",
+ "trait-ffi",
+]
+
+[[package]]
 name = "axlog"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "cfg-if",
  "crate_interface 0.1.4",
@@ -517,17 +681,12 @@ dependencies = [
 
 [[package]]
 name = "axmm"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axalloc",
- "axconfig",
  "axerrno 0.2.2",
- "axfs",
- "axfs-ng-vfs",
  "axhal",
- "axsync",
- "axtask",
- "enum_dispatch",
  "kspin",
  "lazyinit",
  "log",
@@ -537,14 +696,33 @@ dependencies = [
 
 [[package]]
 name = "axnet"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+dependencies = [
+ "axdriver",
+ "axerrno 0.2.2",
+ "axhal",
+ "axio",
+ "axsync",
+ "axtask",
+ "cfg-if",
+ "lazyinit",
+ "log",
+ "spin 0.10.0",
+ "starry-smoltcp",
+]
+
+[[package]]
+name = "axnet-ng"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "async-channel",
  "async-trait",
  "axconfig",
  "axdriver",
  "axerrno 0.2.2",
- "axfs",
+ "axfs-ng",
  "axfs-ng-vfs",
  "axhal",
  "axio",
@@ -565,9 +743,9 @@ dependencies = [
 
 [[package]]
 name = "axplat"
-version = "0.3.1-pre.4"
+version = "0.3.1-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f972b5688b51e8865a33f5282a8e481bfa3f1d1065e0877f8e33532a90680370"
+checksum = "b7e82da07eb9c931a90029d80ae487b4dd532cdf69d44ae692776bbd72e6708a"
 dependencies = [
  "axplat-macros",
  "bitflags 2.11.0",
@@ -581,12 +759,12 @@ dependencies = [
 
 [[package]]
 name = "axplat-aarch64-peripherals"
-version = "0.3.1-pre.4"
+version = "0.3.1-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e2b95a4afcb0af021f7044d56684f88ef22f9d7d64a787b89654e1476803289"
+checksum = "6f3819d30fa3a4038c0f9ab7e122c8b3ba840b323ee3fc19e4dbabe22b4e56ac"
 dependencies = [
- "aarch64-cpu",
- "arm-gic-driver",
+ "aarch64-cpu 11.2.0",
+ "arm-gic-driver 0.16.4",
  "arm_pl011",
  "arm_pl031",
  "axcpu",
@@ -600,9 +778,9 @@ dependencies = [
 
 [[package]]
 name = "axplat-aarch64-qemu-virt"
-version = "0.3.1-pre.4"
+version = "0.3.1-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e3ca1ed89c348ca64b347a185409d1002195713a59f89ded6f78d97cab5927"
+checksum = "ccbc5793ffa4ae120815f3761bea658e0bafeba2d1a5f324cb457de8d41fbfa9"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -613,10 +791,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axplat-dyn"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+dependencies = [
+ "anyhow",
+ "axconfig-macros",
+ "axcpu",
+ "axerrno 0.2.2",
+ "axklib",
+ "axplat",
+ "heapless 0.9.2",
+ "log",
+ "percpu",
+ "somehal",
+ "spin 0.10.0",
+]
+
+[[package]]
 name = "axplat-loongarch64-qemu-virt"
-version = "0.3.1-pre.4"
+version = "0.3.1-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1752817afe5b6e90d3c0824f14f02fd07115f3d07c915411afd87aa978fa204e"
+checksum = "e95a7a015c7ff23303f5807d1f28c31c15c09dd167f192757000f0ca201f29a8"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -643,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "axplat-riscv64-qemu-virt"
-version = "0.3.1-pre.4"
+version = "0.3.1-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a13b1ffa5ba4da587243119dd96aeafac90625e1c37d7b542d52ad6a600324"
+checksum = "7c9f0161378a2bd66773ed208a461ecf36b1c9aae977fbb75d51a271b2790fe8"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -681,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "axplat-x86-pc"
-version = "0.3.1-pre.4"
+version = "0.3.1-pre.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be02ad620dd705988d71af91c6a6865ae0c897a833ddebb6d458f6aa68bb1b4d"
+checksum = "02c2a75cf2d03a8a0ab223d124d434a80f03bb365b5bb616f019c4ac97288c96"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -717,7 +913,8 @@ dependencies = [
 
 [[package]]
 name = "axruntime"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axalloc",
  "axbacktrace",
@@ -725,13 +922,17 @@ dependencies = [
  "axdisplay",
  "axdriver",
  "axfs",
+ "axfs-ng",
  "axhal",
  "axinput",
+ "axklib",
  "axlog",
  "axmm",
  "axnet",
+ "axnet-ng",
  "axplat",
  "axtask",
+ "cfg-if",
  "chrono",
  "crate_interface 0.1.4",
  "ctor_bare",
@@ -750,7 +951,8 @@ dependencies = [
 
 [[package]]
 name = "axsync"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axtask",
  "event-listener",
@@ -760,7 +962,8 @@ dependencies = [
 
 [[package]]
 name = "axtask"
-version = "0.2.0"
+version = "0.3.0-preview.1"
+source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
 dependencies = [
  "axconfig",
  "axerrno 0.2.2",
@@ -780,6 +983,17 @@ dependencies = [
  "memory_addr",
  "percpu",
  "spin 0.10.0",
+]
+
+[[package]]
+name = "bare-test-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e585a01076fee271c5aabcf36212acb349fb3e638561d842fffa8ca013f4fdd8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -859,10 +1073,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "buddy_system_allocator"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b672b945a3e4f4f40bfd4cd5ee07df9e796a42254ce7cd6d2599ad969244c44a"
+dependencies = [
+ "spin 0.10.0",
+]
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "utf8-width",
+]
 
 [[package]]
 name = "bytemuck"
@@ -889,6 +1128,15 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "cap_access"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9b24894fa5f73bbf9c72196e7f495a1f81d6218a548280a09ada4a937157692"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "cexpr"
@@ -1000,6 +1248,15 @@ checksum = "413d67b29ef1021b4d60f4aa1e925ca031751e213832b4b1d588fae623c05c60"
 
 [[package]]
 name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
@@ -1085,8 +1342,28 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.4",
+ "darling_macro 0.13.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -1104,14 +1381,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1170,12 +1497,24 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
- "convert_case",
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.117",
  "unicode-xid",
+]
+
+[[package]]
+name = "dma-api"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3816a852c6c71653e1941cfe22f215eca41c14fd45ec9b32c0fa82fe57fe0989"
+dependencies = [
+ "aarch64-cpu-ext",
+ "cfg-if",
+ "spin 0.10.0",
+ "thiserror",
 ]
 
 [[package]]
@@ -1267,10 +1606,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "fdt-edit"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0f564fda6b9389cec0b258a98483b974b6ed37cf4e771222fb49cabe1e260f"
+dependencies = [
+ "enum_dispatch",
+ "fdt-raw 0.1.5",
+ "log",
+]
+
+[[package]]
 name = "fdt-parser"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f95f0bda5ff920492f6573294d8e3a99b75ee2e5ef93ab313fc6d517fa46785"
+
+[[package]]
+name = "fdt-raw"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7b19f67663e8368d5a07165a1c348b5a761afe5d130e982a0ed8859aca37c2"
+dependencies = [
+ "heapless 0.9.2",
+ "log",
+ "thiserror",
+]
+
+[[package]]
+name = "fdt-raw"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cce2d6b3100c219add1cf704f0996cd45003fee5f1a2567397625c62cb7688f4"
+dependencies = [
+ "heapless 0.9.2",
+ "log",
+ "thiserror",
+]
 
 [[package]]
 name = "flatten_objects"
@@ -1300,10 +1672,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
@@ -1315,6 +1723,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -1330,6 +1744,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -1456,7 +1871,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831739f8836b05db933f3a84783a5af48bd605915dcd10c7435bc74e7947a030"
 dependencies = [
- "darling",
+ "darling 0.13.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1493,6 +1908,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasm-aarch64"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791dc7a2b079d81b8e3615521fccbd75c0c9f068b53f7d891a2e300222c7cada"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "kernel-elf-parser"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1511,6 +1938,17 @@ checksum = "d10c55bedf6789bc3748e0d8756ee639df1ae25144fd3525ed311044bd9a739f"
 dependencies = [
  "cfg-if",
  "crate_interface 0.1.4",
+]
+
+[[package]]
+name = "kernutil"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baabe1075575d14a32c232dbe55699a2908326f0b2022243ae4a069ff02ccb9a"
+dependencies = [
+ "heapless 0.9.2",
+ "num-align",
+ "ranges-ext",
 ]
 
 [[package]]
@@ -1537,6 +1975,35 @@ name = "lazyinit"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f03abfebdaaf0fad16790237a0348baf84886d3ade460db13bae59e614a180"
+
+[[package]]
+name = "lenient_semver"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8de3f4f3754c280ce1c8c42ed8dd26a9c8385c2e5ad4ec5a77e774cea9c1ec"
+dependencies = [
+ "lenient_semver_parser",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_parser"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f650c1d024ddc26b4bb79c3076b30030f2cf2b18292af698c81f7337a64d7d6"
+dependencies = [
+ "lenient_semver_version_builder",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_version_builder"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9049f8ff49f75b946f95557148e70230499c8a642bf2d6528246afc7d0282d17"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "libc"
@@ -1637,6 +2104,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
+name = "mbarrier"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9257ea6fe9726d1f1a67fddbda4c06cc97b4fb18716b78ec03ba05e29d625e28"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1674,6 +2147,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "mmio-api"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38dbaed06bee87e5596f6c27abc62315aa6344c7e5d0db8ee83de98be404283"
+dependencies = [
+ "derive_more",
+ "thiserror",
+]
+
+[[package]]
 name = "multiboot"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1691,6 +2174,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "num-align"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4b86e8ef968de2261141fc760ee57cae8fabb3a0e756b3390a4c4871b16c3d1"
 
 [[package]]
 name = "num-traits"
@@ -1721,6 +2210,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "numeric-enum-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e4bdb6b46b592948e700ea1ef24a4296491f6a0ee722b258040abd15a3714"
 
 [[package]]
 name = "once_cell"
@@ -1759,12 +2254,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "page-table-generic"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062719187d8cadefaabc0c07c12bd486f8e88760fc02b756da3053f42dff0b4d"
+dependencies = [
+ "bitflags 2.11.0",
+ "heapless 0.9.2",
+ "log",
+ "num-align",
+ "thiserror",
+]
+
+[[package]]
 name = "page_table_entry"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9a63b9b86d32f64c3874a90936939281d045ef1751d0aca3d82d5e4e06b2ef"
 dependencies = [
- "aarch64-cpu",
+ "aarch64-cpu 11.2.0",
  "bitflags 2.11.0",
  "memory_addr",
  "x86_64",
@@ -1793,23 +2301,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
-name = "percpu"
-version = "0.2.2"
+name = "pci_types"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54ca06381bdd16a5397e23cf61d347b539c765e2c20b2ecc5cb36df88695c1f7"
+checksum = "f0c2a105c657261a938ff68ee231c199a3d80eef33976004829de761ef5b1a9b"
+dependencies = [
+ "bit_field",
+ "bitflags 2.11.0",
+]
+
+[[package]]
+name = "pcie"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b1339d53c73a04833791fa907b60ff074b95cae8db9f94f3173ed2b30b5b6c"
+dependencies = [
+ "bare-test-macros",
+ "bit_field",
+ "bitflags 2.11.0",
+ "log",
+ "pci_types",
+ "rdif-pcie",
+ "thiserror",
+]
+
+[[package]]
+name = "percpu"
+version = "0.2.3-preview.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c03ecfaf97c11a791d8b65e34a6353d012a735a5cbfebba34ee6668da16ce38"
 dependencies = [
  "cfg-if",
  "kernel_guard",
  "percpu_macros",
- "spin 0.9.8",
+ "spin 0.10.0",
  "x86",
 ]
 
 [[package]]
 name = "percpu_macros"
-version = "0.2.2"
+version = "0.2.3-preview.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a933d46113c0171aee86623311a9367f2ec3a86dab0a96aba1d5bc627473617e"
+checksum = "6660d83b91174e6d39fae0cdf893889dcdbffda6e99664f8ee8a45fde6a6936c"
 dependencies = [
  "cfg-if",
  "proc-macro2",
@@ -1893,6 +2426,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9a0cf95a1196af61d4f1cbdab967179516d9a4a4312af1f31948f8f6224a79"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7347867d0a7e1208d93b46767be83e2b8f978c3dad35f775ac8d8847551d6fe1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1900,6 +2453,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -1917,6 +2476,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
+name = "ranges-ext"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7dbbaa030b3eec58088755e56d3acb775fc74f4726565eda8633a415bfc44e0"
+dependencies = [
+ "heapless 0.9.2",
+ "thiserror",
+]
+
+[[package]]
 name = "raw-cpuid"
 version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1932,6 +2501,104 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "rdif-base"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f8c32d8cbc18633a412130719b07d31135215d1715ac48fc3888ca835a811ba"
+dependencies = [
+ "as-any",
+ "async-trait",
+ "paste",
+ "rdif-def",
+ "thiserror",
+]
+
+[[package]]
+name = "rdif-base"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda8c6ace8e0124ec777028cf86a56049f039c5d6f7a19b307a3f564b01ed858"
+dependencies = [
+ "as-any",
+ "async-trait",
+ "paste",
+ "rdif-def",
+ "thiserror",
+]
+
+[[package]]
+name = "rdif-def"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb161fd5654843a0fc86866f3342f41622a589ecf4ebb33ec313a593fd235b4"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "rdif-intc"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f3b9bf119dea83dcc7e4f0e2487d7635d373f55500bde982defa934dd17e9c"
+dependencies = [
+ "cfg-if",
+ "rdif-base 0.8.0",
+]
+
+[[package]]
+name = "rdif-pcie"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4ab8ecf37d86123500a1d99519424b7dcf2489c0df6b62b56af9f436224259f"
+dependencies = [
+ "pci_types",
+ "rdif-base 0.8.0",
+ "thiserror",
+]
+
+[[package]]
+name = "rdif-serial"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6668610226177053d66d9d3e55436cfa44f6428a5b755b9d7593288b738e3f12"
+dependencies = [
+ "bitflags 2.11.0",
+ "futures",
+ "heapless 0.9.2",
+ "rdif-base 0.7.0",
+ "spin 0.10.0",
+ "thiserror",
+]
+
+[[package]]
+name = "rdrive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab4f7c92af8670536001b449bf8d27c67c22ff5f2391dd76ca2da9b5c5343f40"
+dependencies = [
+ "fdt-parser",
+ "log",
+ "paste",
+ "pcie",
+ "rdif-base 0.8.0",
+ "rdif-pcie",
+ "rdrive-macros",
+ "spin 0.10.0",
+ "thiserror",
+]
+
+[[package]]
+name = "rdrive-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab3105c9af32e901a2adc7d920b39ff8b6ee0f6f0b7dfdeaf18f306ec12606f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1962,6 +2629,15 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ringbuf"
@@ -2062,6 +2738,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsext4"
+version = "0.1.0-pre.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32c9e89b7c4314992d8b2f6147e8637cc7a578a8d0df083e516bde4b23a0b25d"
+dependencies = [
+ "bitflags 2.11.0",
+ "lazy_static",
+ "log",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61f703d19852dbf87cbc513643fa81428361eb6940f1ac14fd58155d295a3eb0"
+dependencies = [
+ "arrayvec",
+ "num-traits",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2105,9 +2802,9 @@ checksum = "e6e36312fb5ddc10d08ecdc65187402baba4ac34585cb9d1b78522ae2358d890"
 
 [[package]]
 name = "scope-local"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a7d5ed5013e6436fcd78f2bcd3892a6286ef9ce6c9b61504d4c4a08d6a40eab"
+checksum = "c80f3dd0611957c9384d8e5b076236a265e873b41dcae7ccc5d1ba4fe58e32ae"
 dependencies = [
  "percpu",
  "spin 0.10.0",
@@ -2155,6 +2852,111 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smccc"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c73e0ca8c566478040487791c9f488f86c5aec846ca1ab18484be8a1d8c55cd"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
+name = "some-serial"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20ad586f110c679176859fe111f2c3dd176b95bbe731e9b4c3d1c6382cb301c9"
+dependencies = [
+ "bare-test-macros",
+ "bitflags 2.11.0",
+ "dma-api",
+ "enum_dispatch",
+ "heapless 0.9.2",
+ "log",
+ "mbarrier",
+ "rdif-serial",
+ "thiserror",
+ "tock-registers 0.10.1",
+ "x86",
+]
+
+[[package]]
+name = "someboot"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d098355236a04942502f316661e06e8df92ac0e0db1c6c25922bab4b08e8317"
+dependencies = [
+ "aarch64-cpu 11.2.0",
+ "aarch64-cpu-ext",
+ "acpi",
+ "aml",
+ "ansi_rgb",
+ "anyhow",
+ "arrayvec",
+ "bit_field",
+ "bitflags 2.11.0",
+ "buddy_system_allocator",
+ "byte-unit",
+ "byteorder",
+ "derive_more",
+ "fdt-edit",
+ "fdt-raw 0.2.0",
+ "heapless 0.9.2",
+ "kasm-aarch64",
+ "kernutil",
+ "log",
+ "loongArch64",
+ "num-align",
+ "numeric-enum-macro",
+ "page-table-generic",
+ "prettyplease",
+ "quote",
+ "ranges-ext",
+ "rgb",
+ "smccc",
+ "some-serial",
+ "somehal-macros",
+ "spin 0.10.0",
+ "syn 2.0.117",
+ "thiserror",
+ "tock-registers 0.10.1",
+ "uefi",
+ "uguid",
+]
+
+[[package]]
+name = "somehal"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0959f802461a5c3458a5eff143d0622f3710946b3c47129e20be257fb9648bb4"
+dependencies = [
+ "aarch64-cpu 11.2.0",
+ "anyhow",
+ "arm-gic-driver 0.17.0",
+ "kernutil",
+ "log",
+ "mmio-api",
+ "page-table-generic",
+ "rdif-intc",
+ "rdrive",
+ "someboot",
+ "somehal-macros",
+ "thiserror",
+ "tock-registers 0.10.1",
+]
+
+[[package]]
+name = "somehal-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38cc4ec03fa0bf03efcaf2b829371f3e08862df67be679009ff2ba6e87a3a7b8"
+dependencies = [
+ "darling 0.21.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,6 +2970,24 @@ name = "spin"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
 dependencies = [
  "lock_api",
 ]
@@ -2189,14 +3009,14 @@ dependencies = [
  "axdriver",
  "axerrno 0.2.2",
  "axfeat",
- "axfs",
+ "axfs-ng",
  "axfs-ng-vfs",
  "axhal",
  "axinput",
  "axio",
  "axlog",
  "axmm",
- "axnet",
+ "axnet-ng",
  "axpoll",
  "axruntime",
  "axsync",
@@ -2391,6 +3211,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81c645a4de0d803ced6ef0388a2646aa1ef8467173b5d59a2c33c88de4ab76e7"
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2415,6 +3241,12 @@ name = "tock-registers"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "696941a0aee7e276a165a978b37918fd5d22c55c3d6bda197813070ca9c0f21c"
+
+[[package]]
+name = "tock-registers"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b9e2fdb3a1e862c0661768b7ed25390811df1947a8acbfbefe09b47078d93c4"
 
 [[package]]
 name = "tock-registers"
@@ -2447,6 +3279,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
+name = "trait-ffi"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d49469ee333631b3130bec28965c47dcf0d4f3a792f8ed425dd036cf84be7"
+dependencies = [
+ "convert_case 0.8.0",
+ "lenient_semver",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,6 +3307,58 @@ dependencies = [
  "rustversion",
  "x86",
 ]
+
+[[package]]
+name = "ucs2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79298e11f316400c57ec268f3c2c29ac3c4d4777687955cd3d4f3a35ce7eba"
+dependencies = [
+ "bit_field",
+]
+
+[[package]]
+name = "uefi"
+version = "0.36.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe9058b73ee2b6559524af9e33199c13b2485ddbf3ad1181b68051cdc50c17"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "log",
+ "ptr_meta",
+ "ucs2",
+ "uefi-macros",
+ "uefi-raw",
+ "uguid",
+]
+
+[[package]]
+name = "uefi-macros"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4687412b5ac74d245d5bfb1733ede50c31be19bf8a4b6a967a29b451bab49e67"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "uefi-raw"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f64fe59e11af447d12fd60a403c74106eb104309f34b4c6dbce6e927d97da9d"
+dependencies = [
+ "bitflags 2.11.0",
+ "uguid",
+]
+
+[[package]]
+name = "uguid"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8352f8c05e47892e7eaf13b34abd76a7f4aeaf817b716e88789381927f199c"
 
 [[package]]
 name = "uluru"
@@ -2495,6 +3392,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
 
 [[package]]
 name = "utf8parse"
@@ -2574,6 +3477,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,8 +253,9 @@ dependencies = [
 
 [[package]]
 name = "axalloc"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a10c400cbdf0f611f92fcdd6e2c658de329085d3156ba65e323da7eaa7c7aca"
 dependencies = [
  "axallocator",
  "axbacktrace",
@@ -296,8 +297,9 @@ dependencies = [
 
 [[package]]
 name = "axconfig"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25985c64d932bf954b02eaf0873e4445d234d39b5100b1985585e3276b6b47d1"
 dependencies = [
  "axconfig-macros",
 ]
@@ -326,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "axcpu"
-version = "0.3.0-preview.6"
+version = "0.3.0-preview.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61dc8203ac5b80e4aa613c1139b1c69b908aededadd1ae7c55b41da06084a2ad"
+checksum = "361edfc761188b19fb3d906b0b155942a6290068ee88d42f3b1f0ce31dcd099e"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "axbacktrace",
@@ -350,8 +352,9 @@ dependencies = [
 
 [[package]]
 name = "axdisplay"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "202dbb36844c1822040957ecfbcf467a7dddbc183fe3e89d098523d3fc00e64a"
 dependencies = [
  "axdriver",
  "axsync",
@@ -361,8 +364,9 @@ dependencies = [
 
 [[package]]
 name = "axdriver"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a92c9e28dbeeb219f91abed250fa9e04d3cd28a6d5d296fc2fb46a8b99d8f86"
 dependencies = [
  "axalloc",
  "axconfig",
@@ -494,8 +498,9 @@ dependencies = [
 
 [[package]]
 name = "axfeat"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abc9f576faa89f8ffb6a56e521fcf4eccf47fc4321afa93a3c5b769d4fbaafa"
 dependencies = [
  "axalloc",
  "axbacktrace",
@@ -515,8 +520,9 @@ dependencies = [
 
 [[package]]
 name = "axfs"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c4cf42f326689f0365e3f08b7b8d59fcee360a82b343674eaf375439ea6051"
 dependencies = [
  "axdriver",
  "axerrno 0.2.2",
@@ -534,8 +540,9 @@ dependencies = [
 
 [[package]]
 name = "axfs-ng"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda01a3d5334aef9764462e9e06639de220490f897a85749444bac4517d6edd4"
 dependencies = [
  "axalloc",
  "axdriver",
@@ -610,8 +617,9 @@ dependencies = [
 
 [[package]]
 name = "axhal"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b721414abb9554522acdc0495cef83eadfc7d47257fe3c979e655c982d79588"
 dependencies = [
  "axalloc",
  "axconfig",
@@ -636,8 +644,9 @@ dependencies = [
 
 [[package]]
 name = "axinput"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e3d30c4cfd7b920fe5d7fb4a79ad019c25b8620a75bf83e96a54f9653f4217d"
 dependencies = [
  "axdriver",
  "axsync",
@@ -670,8 +679,9 @@ dependencies = [
 
 [[package]]
 name = "axlog"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45965ea9b795e917fe01be525d69c4ad4d455fe8fa5cd512b2e340aca8ed3ff4"
 dependencies = [
  "cfg-if",
  "crate_interface 0.1.4",
@@ -681,8 +691,9 @@ dependencies = [
 
 [[package]]
 name = "axmm"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49440d27560749ce68ed60e44377772f09a4beaae3f96e1b875c4794b29c8e64"
 dependencies = [
  "axalloc",
  "axerrno 0.2.2",
@@ -696,8 +707,9 @@ dependencies = [
 
 [[package]]
 name = "axnet"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03ce184f77f748369b6fa315385e2093c159d1a08d6ce18beec9fad6d2c27f6"
 dependencies = [
  "axdriver",
  "axerrno 0.2.2",
@@ -714,8 +726,9 @@ dependencies = [
 
 [[package]]
 name = "axnet-ng"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3a33a22c3b07301d1cf096021a1f048c0d48b02d5fc034c237fb9968dc06da2"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -743,9 +756,9 @@ dependencies = [
 
 [[package]]
 name = "axplat"
-version = "0.3.1-pre.5"
+version = "0.3.1-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e82da07eb9c931a90029d80ae487b4dd532cdf69d44ae692776bbd72e6708a"
+checksum = "29d8d929fe41fcb361cf784819041f942aba4bcd2d26b9a26305df84e26b206b"
 dependencies = [
  "axplat-macros",
  "bitflags 2.11.0",
@@ -759,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "axplat-aarch64-peripherals"
-version = "0.3.1-pre.5"
+version = "0.3.1-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3819d30fa3a4038c0f9ab7e122c8b3ba840b323ee3fc19e4dbabe22b4e56ac"
+checksum = "a744097da129e66068e4fff6758726c98bf329a7182dcc65712ac80daed581ed"
 dependencies = [
  "aarch64-cpu 11.2.0",
  "arm-gic-driver 0.16.4",
@@ -778,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "axplat-aarch64-qemu-virt"
-version = "0.3.1-pre.5"
+version = "0.3.1-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccbc5793ffa4ae120815f3761bea658e0bafeba2d1a5f324cb457de8d41fbfa9"
+checksum = "dff51219e3ff388368eec683f83b5a8184b3125bac709006f6ac22e435dc07e4"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -792,8 +805,9 @@ dependencies = [
 
 [[package]]
 name = "axplat-dyn"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49b7e7141aba3d361cca262393e75cd924a12adfeaadbd4018936e70916af0"
 dependencies = [
  "anyhow",
  "axconfig-macros",
@@ -810,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "axplat-loongarch64-qemu-virt"
-version = "0.3.1-pre.5"
+version = "0.3.1-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e95a7a015c7ff23303f5807d1f28c31c15c09dd167f192757000f0ca201f29a8"
+checksum = "0bb9c67d904ccf30561a6239b67411058b215cb6d6a8d3ac737e7a51230b40bf"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -839,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "axplat-riscv64-qemu-virt"
-version = "0.3.1-pre.5"
+version = "0.3.1-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9f0161378a2bd66773ed208a461ecf36b1c9aae977fbb75d51a271b2790fe8"
+checksum = "08f91aff22afadd24807e34fb94fe4d0d2c8c5b86fb89dd6ff87a8093f812518"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -877,9 +891,9 @@ dependencies = [
 
 [[package]]
 name = "axplat-x86-pc"
-version = "0.3.1-pre.5"
+version = "0.3.1-pre.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c2a75cf2d03a8a0ab223d124d434a80f03bb365b5bb616f019c4ac97288c96"
+checksum = "9df26719c444ca8302e9366b8dc5abe8735933ea756ff094e3ac5ce3b64c41a1"
 dependencies = [
  "axconfig-macros",
  "axcpu",
@@ -913,8 +927,9 @@ dependencies = [
 
 [[package]]
 name = "axruntime"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce5c658dc9a0e283dafb99317ade2bb191d3881b2133ac58da251d03f589f83f"
 dependencies = [
  "axalloc",
  "axbacktrace",
@@ -951,8 +966,9 @@ dependencies = [
 
 [[package]]
 name = "axsync"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb8e90184332ae787f483a256561c6c4eecc4b5b41e06d3850fbd524a8c6a98"
 dependencies = [
  "axtask",
  "event-listener",
@@ -962,8 +978,9 @@ dependencies = [
 
 [[package]]
 name = "axtask"
-version = "0.3.0-preview.1"
-source = "git+https://github.com/arceos-org/arceos.git?rev=84d6236#84d6236ff6a5bd440683873c4da9b2959243cd5e"
+version = "0.3.0-preview.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc45120776afddf28b19bb7aba87e379c5779cf28a8f7884943a4821caeec774"
 dependencies = [
  "axconfig",
  "axerrno 0.2.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ homepage = "https://github.com/Starry-OS"
 repository = "https://github.com/Starry-OS/StarryOS"
 
 [workspace.dependencies]
-axfeat = { path = "arceos/api/axfeat" }
+axfeat = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
 
-axalloc = { path = "arceos/modules/axalloc" }
-axconfig = { path = "arceos/modules/axconfig" }
-axdisplay = { path = "arceos/modules/axdisplay" }
-axdriver = { path = "arceos/modules/axdriver" }
-axfs = { path = "arceos/modules/axfs" }
-axhal = { path = "arceos/modules/axhal" }
-axinput = { path = "arceos/modules/axinput" }
-axlog = { path = "arceos/modules/axlog" }
-axmm = { path = "arceos/modules/axmm" }
-axnet = { path = "arceos/modules/axnet" }
-axruntime = { path = "arceos/modules/axruntime" }
-axsync = { path = "arceos/modules/axsync" }
-axtask = { path = "arceos/modules/axtask" }
+axalloc = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axconfig = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axdisplay = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axdriver = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axfs = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236", package = "axfs-ng" }
+axhal = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axinput = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axlog = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axmm = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axnet = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236", package = "axnet-ng" }
+axruntime = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axsync = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axtask = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
 
 starry-kernel = { path = "kernel" }
 
@@ -58,7 +58,7 @@ qemu = [
     "starry-kernel/vsock",
 
     # auxilary features
-    "axfeat/fs-times",
+    "axfeat/fs-ng-times",
     "starry-kernel/dev-log",
 ]
 smp = ["axfeat/smp", "axplat-riscv64-visionfive2?/smp"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,21 @@ homepage = "https://github.com/Starry-OS"
 repository = "https://github.com/Starry-OS/StarryOS"
 
 [workspace.dependencies]
-axfeat = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axfeat = { version = "0.3.0-preview.2" }
 
-axalloc = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
-axconfig = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
-axdisplay = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
-axdriver = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
-axfs = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236", package = "axfs-ng" }
-axhal = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
-axinput = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
-axlog = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
-axmm = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
-axnet = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236", package = "axnet-ng" }
-axruntime = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
-axsync = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
-axtask = { git = "https://github.com/arceos-org/arceos.git", rev = "84d6236" }
+axalloc = { version = "0.3.0-preview.2" }
+axconfig = { version = "0.3.0-preview.2" }
+axdisplay = { version = "0.3.0-preview.2" }
+axdriver = { version = "0.3.0-preview.2" }
+axfs = { version = "0.3.0-preview.2", package = "axfs-ng" }
+axhal = { version = "0.3.0-preview.2" }
+axinput = { version = "0.3.0-preview.2" }
+axlog = { version = "0.3.0-preview.2" }
+axmm = { version = "0.3.0-preview.2" }
+axnet = { version = "0.3.0-preview.2", package = "axnet-ng" }
+axruntime = { version = "0.3.0-preview.2" }
+axsync = { version = "0.3.0-preview.2" }
+axtask = { version = "0.3.0-preview.2" }
 
 starry-kernel = { path = "kernel" }
 

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -15,17 +15,21 @@ vsock = ["axfeat/vsock"]
 
 [dependencies]
 axfeat = { workspace = true, features = [
-    "alloc-slab",
     "fp-simd",
-    "fs-ext4",
     "irq",
-    "multitask",
-    "net",
-    "page-alloc-4g",
-    "rtc",
-    "sched-rr",
-    "task-ext",
     "uspace",
+
+    "page-alloc-4g",
+    "alloc-slab",
+
+    "multitask",
+    "task-ext",
+    "sched-rr",
+
+    "rtc",
+
+    "fs-ng-ext4",
+    "net-ng",
 ] }
 
 axalloc.workspace = true
@@ -80,7 +84,7 @@ memory_addr = "0.4"
 memory_set = "0.4"
 num_enum = { version = "0.7", default-features = false }
 ouroboros = { version = "0.18.5", default-features = false }
-percpu = "0.2.0"
+percpu = "0.2.3-preview.1"
 rand = { version = "0.10", default-features = false, features = ["alloc"] }
 ringbuf = { version = "0.4.8", default-features = false, features = ["alloc"] }
 scope-local = "0.1"


### PR DESCRIPTION
Waiting for arceos be ready to be published on crates.io