### PR TITLE
fix(riscv64): boot StarryOS with RustSBI on riscv64 without IllegalInstruction trap

### DIFF
--- a/kernel/src/entry.rs
+++ b/kernel/src/entry.rs
@@ -16,8 +16,18 @@ use crate::{
     task::{ProcessData, Thread, add_task_to_table, new_user_task, spawn_alarm_task},
 };
 
+#[cfg(target_arch = "riscv64")]
+#[inline]
+fn init_riscv_fp_state() {
+    use riscv::register::sstatus::{self, FS};
+    unsafe { sstatus::set_fs(FS::Dirty) };
+}
+
 /// Initialize and run initproc.
 pub fn init(args: &[String], envs: &[String]) {
+    #[cfg(target_arch = "riscv64")]
+    init_riscv_fp_state();
+
     pseudofs::mount_all().expect("Failed to mount pseudofs");
     spawn_alarm_task();
 

--- a/make/Makefile
+++ b/make/Makefile
@@ -27,6 +27,7 @@
 #     - `MEM`: Memory size (default is 128M)
 #     - `DISK_IMG`: Path to the virtual disk image
 #     - `ACCEL`: Enable hardware acceleration (KVM on linux)
+#     - `QEMU_BIOS`: QEMU BIOS firmware path (default is `default`)
 #     - `QEMU_LOG`: Enable QEMU logging (log file is "qemu.log")
 #     - `NET_DUMP`: Enable network packet dump (log file is "netdump.pcap")
 #     - `NET_DEV`: QEMU netdev backend types: user, tap, bridge
@@ -69,6 +70,7 @@ MEM ?=
 ACCEL ?=
 ICOUNT ?= n
 QEMU_ARGS ?=
+QEMU_BIOS ?= default
 
 DISK_IMG ?= disk.img
 QEMU_LOG ?= n

--- a/make/qemu.mk
+++ b/make/qemu.mk
@@ -2,6 +2,7 @@
 
 QEMU := qemu-system-$(ARCH)
 
+
 ifeq ($(BUS), mmio)
   vdev-suffix := device
 else ifeq ($(BUS), pci)
@@ -30,7 +31,7 @@ qemu_args-x86_64 := \
 
 qemu_args-riscv64 := \
   -machine $(machine) \
-  -bios default \
+  -bios $(QEMU_BIOS) \
   -kernel $(FINAL_IMG)
 
 qemu_args-aarch64 := \


### PR DESCRIPTION
Closes #130

### Background

When booting StarryOS with RustSBI on riscv64, the kernel could panic with:

- `Unhandled trap Exception(IllegalInstruction)`
- `sepc=0xffffffc08037499c`
- `stval=0xf2000053`
- stack trace around `axtask::run_queue::switch_to`

The same image could boot with default BIOS, indicating a firmware-dependent init assumption.

### Root Cause

The fp-simd path could execute before FP state was explicitly initialized for this boot path.
With RustSBI, this exposed an initialization gap and resulted in an illegal instruction trap.

### Changes

- This PR is split into two commits:
- 1) riscv64 boot fix (core bugfix for #130)
- 2) Make/QEMU BIOS configurability (repro and validation convenience)

1. `kernel/src/entry.rs`
   - Added riscv64-specific early init helper:
     - `init_riscv_fp_state()`
     - sets `riscv::register::sstatus::FS` to `FS::Dirty`
   - Called it at the beginning of `entry::init()` before user init work.

2. `make/Makefile`
   - Added configurable variable:
     - `QEMU_BIOS ?= default`
   - Documented `QEMU_BIOS` in QEMU options comment block.

3. `make/qemu.mk`
   - Updated riscv64 QEMU args:
     - from `-bios default`
     - to `-bios $(QEMU_BIOS)`

This allows direct reproduction and verification with RustSBI via:

```bash
make run QEMU_BIOS=../rustsbi-prototyper-dynamic.bin
```

### Validation Performed

- A-group (before fix): RustSBI boot reproduced `IllegalInstruction` trap.
- B diagnostic (temporary): removing `fp-simd` removed the trap, confirming FP-state relation.
- A-fixed (with final fix, fp-simd enabled): RustSBI boot reached shell successfully.
- Default BIOS control: still boots to shell successfully.
- `ci-test`: passes (`Boot into BusyBox shell`).

### Impact

- Fixes issue #130 reproducibly on riscv64 with RustSBI.
- Makes boot behavior less dependent on firmware default CPU state.

## Files Included In This PR

- `kernel/src/entry.rs`
- `make/Makefile`
- `make/qemu.mk`

- I’m still learning kernel development, so feedback is very welcome.
- If any part of this fix should be done differently, I’m happy to revise.